### PR TITLE
Allow to set existing secrets

### DIFF
--- a/charts/openproject/Chart.yaml
+++ b/charts/openproject/Chart.yaml
@@ -5,8 +5,8 @@ description: "A Helm chart for running OpenProject via Kubernetes"
 home: "https://www.openproject.org/"
 icon: "https://www.openproject.org/assets/images/press/openproject-icon-original-color-41055eb6.png"
 type: "application"
-version: "1.6.0"
-appVersion: "12.4"
+version: "1.7.0"
+appVersion: "12.5"
 maintainers:
   - name: OpenProject
     url: https://github.com/opf/helm-charts

--- a/charts/openproject/Chart.yaml
+++ b/charts/openproject/Chart.yaml
@@ -6,7 +6,7 @@ home: "https://www.openproject.org/"
 icon: "https://www.openproject.org/assets/images/press/openproject-icon-original-color-41055eb6.png"
 type: "application"
 version: "1.7.0"
-appVersion: "12.5"
+appVersion: "12.4"
 maintainers:
   - name: OpenProject
     url: https://github.com/opf/helm-charts

--- a/charts/openproject/templates/deployment.yaml
+++ b/charts/openproject/templates/deployment.yaml
@@ -63,6 +63,25 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ include "common.names.fullname" . }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ .Values.extraEnvVarsSecret }}
+            {{- end }}
+          env:
+          {{- if .Values.postgresql.auth.existingSecret }}
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretRef:
+                  name: {{ .Values.postgresql.auth.secretKeys.userPasswordKey }}
+                  key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey }}          
+          {{- if .Values.postgresql.bundled }}
+            - name: DATABASE_URL
+              value: "postgresql://{{ .Values.postgresql.auth.username }}:$(DATABASE_PASSWORD)@{{ include "common.names.dependency.fullname" (dict "chartName" "postgresql" "chartValues" .Values.postgresql "context" $) }}:{{ .Values.postgresql.primary.service.ports.postgresql }}/{{ .Values.postgresql.auth.database }}"
+          {{- else }}
+            - name: DATABASE_URL
+              value: "postgresql://{{ .Values.postgresql.auth.username }}:$(DATABASE_PASSWORD)@{{ .Values.postgresql.connection.host }}:{{ .Values.postgresql.connection.port }}/{{ .Values.postgresql.auth.database }}"
+          {{- end }}
+          {{- end }}
           {{- if .Values.persistence.enabled }}
           volumeMounts:
             - name: "data"

--- a/charts/openproject/templates/deployment.yaml
+++ b/charts/openproject/templates/deployment.yaml
@@ -67,8 +67,8 @@ spec:
             - secretRef:
                 name: {{ .Values.extraEnvVarsSecret }}
             {{- end }}
-          env:
           {{- if .Values.postgresql.auth.existingSecret }}
+          env:
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretRef:

--- a/charts/openproject/templates/deployment.yaml
+++ b/charts/openproject/templates/deployment.yaml
@@ -71,8 +71,8 @@ spec:
           env:
             - name: DATABASE_PASSWORD
               valueFrom:
-                secretRef:
-                  name: {{ .Values.postgresql.auth.secretKeys.userPasswordKey }}
+                secretKeyRef:
+                  name: {{ .Values.postgresql.auth.existingSecret }}
                   key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey }}          
           {{- if .Values.postgresql.bundled }}
             - name: DATABASE_URL

--- a/charts/openproject/templates/secrets.yaml
+++ b/charts/openproject/templates/secrets.yaml
@@ -6,20 +6,24 @@ metadata:
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 stringData:
+  {{- if not (or .Values.postgresql.global.postgresql.auth.existingSecret .Values.postgresql.auth.existingSecret) -}}
   {{- if .Values.postgresql.bundled }}
   DATABASE_URL: "postgresql://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ include "common.names.dependency.fullname" (dict "chartName" "postgresql" "chartValues" .Values.postgresql "context" $) }}:{{ .Values.postgresql.primary.service.ports.postgresql }}/{{ .Values.postgresql.auth.database }}"
   {{- else }}
   DATABASE_URL: "postgresql://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Values.postgresql.connection.host }}:{{ .Values.postgresql.connection.port }}/{{ .Values.postgresql.auth.database }}"
+  {{- end }}
   {{- end }}
   OPENPROJECT_HTTPS: {{ .Values.openproject.https | quote }}
   OPENPROJECT_HOST__NAME: {{ .Values.openproject.host | default .Values.ingress.host | quote }}
   OPENPROJECT_HSTS: {{ .Values.openproject.hsts | quote }}
   OPENPROJECT_RAILS__CACHE__STORE: {{ .Values.openproject.cache.store | quote }}
   {{- if eq .Values.openproject.cache.store "memcache" }}
+  {{- if not .Values.memcached.auth.existingPasswordSecret }}
   {{- if .Values.memcached.bundled }}
   OPENPROJECT_CACHE__MEMCACHE__SERVER: "{{ .Release.Name }}-memcached:11211"
   {{- else }}
   OPENPROJECT_CACHE__MEMCACHE__SERVER: "{{ .Values.memcached.connection.host }}:{{.Values.memcached.connection.port }}"
+  {{- end }}
   {{- end }}
   {{- end }}
   OPENPROJECT_RAILS__RELATIVE__URL__ROOT: {{ .Values.openproject.railsRelativeUrlRoot | default "" | quote }}

--- a/charts/openproject/templates/secrets.yaml
+++ b/charts/openproject/templates/secrets.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 stringData:
-  {{- if not (or .Values.postgresql.global.postgresql.auth.existingSecret .Values.postgresql.auth.existingSecret) -}}
+  {{- if not .Values.postgresql.auth.existingSecret -}}
   {{- if .Values.postgresql.bundled }}
   DATABASE_URL: "postgresql://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ include "common.names.dependency.fullname" (dict "chartName" "postgresql" "chartValues" .Values.postgresql "context" $) }}:{{ .Values.postgresql.primary.service.ports.postgresql }}/{{ .Values.postgresql.auth.database }}"
   {{- else }}

--- a/charts/openproject/templates/secrets.yaml
+++ b/charts/openproject/templates/secrets.yaml
@@ -18,12 +18,10 @@ stringData:
   OPENPROJECT_HSTS: {{ .Values.openproject.hsts | quote }}
   OPENPROJECT_RAILS__CACHE__STORE: {{ .Values.openproject.cache.store | quote }}
   {{- if eq .Values.openproject.cache.store "memcache" }}
-  {{- if not .Values.memcached.auth.existingPasswordSecret }}
   {{- if .Values.memcached.bundled }}
   OPENPROJECT_CACHE__MEMCACHE__SERVER: "{{ .Release.Name }}-memcached:11211"
   {{- else }}
   OPENPROJECT_CACHE__MEMCACHE__SERVER: "{{ .Values.memcached.connection.host }}:{{.Values.memcached.connection.port }}"
-  {{- end }}
   {{- end }}
   {{- end }}
   OPENPROJECT_RAILS__RELATIVE__URL__ROOT: {{ .Values.openproject.railsRelativeUrlRoot | default "" | quote }}

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -118,7 +118,7 @@ image:
 
   ## Define image tag.
   ##
-  tag: "12.5"
+  tag: "12.4"
 
   ## Define image sha256 - mutual exclusive with image tag.
   ## The sha256 has a higher precedence than

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -147,12 +147,6 @@ memcached:
     host:
     port:
 
-  ## Memcached auth details.
-  #
-  auth:
-    user: "memcached"
-    password: "memcached"
-    existingPasswordSecret: ""
 ## String to partially override release name.
 #
 nameOverride: ""

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -118,7 +118,7 @@ image:
 
   ## Define image tag.
   ##
-  tag: "12.4"
+  tag: "12.5"
 
   ## Define image sha256 - mutual exclusive with image tag.
   ## The sha256 has a higher precedence than

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -152,7 +152,7 @@ memcached:
   auth:
     user: "memcached"
     password: "memcached"
-
+    existingPasswordSecret: ""
 ## String to partially override release name.
 #
 nameOverride: ""
@@ -195,6 +195,8 @@ openproject:
   #
   cache:
     store: "memcache"
+
+  extraEnvVarsSecret: ""
 
   ## Define OpenID Connect providers
   oidc:
@@ -276,6 +278,11 @@ postgresql:
   ## Database auth details.
   #
   auth:
+    existingSecret: ""
+    secretKeys:
+      adminPasswordKey: ""
+      userPasswordKey: ""
+    
     ## Database username.
     #
     username: "openproject"


### PR DESCRIPTION
Proposed Changes:

- add optional secret for additional env vars
- add existing secret option for Postgres chart (compatible with bundled chart)
- remove memcached auth as the credentials were not used anyway