### PR TITLE
use slim image

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -40,4 +40,4 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install --target-branch ${{ github.event.repository.default_branch }} --chart-repos bitnami=https://charts.bitnami.com/bitnami --helm-extra-set-args "--set environment.OPENPROJECT_HTTPS=false"
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --chart-repos bitnami=https://charts.bitnami.com/bitnami --helm-extra-set-args "--set environment.OPENPROJECT_HTTPS=false" --helm-extra-args "--timeout 600s"

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -40,4 +40,4 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install --target-branch ${{ github.event.repository.default_branch }} --chart-repos bitnami=https://charts.bitnami.com/bitnami
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --chart-repos bitnami=https://charts.bitnami.com/bitnami --helm-extra-set-args "--set environment.OPENPROJECT_HTTPS=false"

--- a/charts/openproject/Chart.yaml
+++ b/charts/openproject/Chart.yaml
@@ -5,7 +5,7 @@ description: "A Helm chart for running OpenProject via Kubernetes"
 home: "https://www.openproject.org/"
 icon: "https://www.openproject.org/assets/images/press/openproject-icon-original-color-41055eb6.png"
 type: "application"
-version: "1.8.1"
+version: "1.9.0"
 appVersion: "12"
 maintainers:
   - name: OpenProject

--- a/charts/openproject/Chart.yaml
+++ b/charts/openproject/Chart.yaml
@@ -5,7 +5,7 @@ description: "A Helm chart for running OpenProject via Kubernetes"
 home: "https://www.openproject.org/"
 icon: "https://www.openproject.org/assets/images/press/openproject-icon-original-color-41055eb6.png"
 type: "application"
-version: "1.9.0"
+version: "2.0.0"
 appVersion: "12"
 maintainers:
   - name: OpenProject

--- a/charts/openproject/README.md
+++ b/charts/openproject/README.md
@@ -31,7 +31,7 @@ kubectl -n openproject create secret tls openproject-tls \
 Set the tls secret value during installation or an upgrade by adding the following.
 
 ```
---set tls.enabled=true --set tls.secretName=openproject-tls
+--set ingress.tls.enabled=true --set tls.secretName=openproject-tls
 ```
 
 #### Root CA

--- a/charts/openproject/README.md
+++ b/charts/openproject/README.md
@@ -4,8 +4,49 @@ This is the chart for OpenProject itself.
 
 ## Development
 
-To install from this directory run the following command.
+To install or update from this directory run the following command.
 
 ```bash
-helm upgrade --create-namespace --namespace openproject --install my-openproject .
+helm upgrade \
+  --create-namespace --namespace openproject \
+  --install --reuse-values openproject-dev .
+```
+
+### TLS
+
+Create a TLS certificate, e.g. using [mkcert](https://github.com/FiloSottile/mkcert).
+
+```
+mkcert helm-example.openproject-dev.com
+```
+
+Create the tls secret in kubernetes.
+
+```
+kubectl -n openproject create secret tls openproject-tls \
+  --key="helm-example.openproject-dev.com-key.pem" \
+  --cert="helm-example.openproject-dev.com.pem"
+```
+
+Set the tls secret value during installation or an upgrade by adding the following.
+
+```
+--set tls.enabled=true --set tls.secretName=openproject-tls
+```
+
+#### Root CA
+
+If you want to add your own root CA for outgoing TLS connection, do the following.
+
+1. Put the certificate into a config map.
+
+```
+kubectl -n openproject-dev create configmap ca-pemstore --from-file=/path/to/rootCA.pem
+```
+
+To make OpenProject use this CA for outgoing TLS connection, set the following options.
+
+```
+  --set egress.tls.rootCA.configMap=ca-pemstore \
+  --set egress.tls.rootCA.fileName=rootCA.pem
 ```

--- a/charts/openproject/README.md
+++ b/charts/openproject/README.md
@@ -1,0 +1,11 @@
+# Helm chart for OpenProject
+
+This is the chart for OpenProject itself.
+
+## Development
+
+To install from this directory run the following command.
+
+```bash
+helm upgrade --create-namespace --namespace openproject --install my-openproject .
+```

--- a/charts/openproject/templates/seeder-job.yaml
+++ b/charts/openproject/templates/seeder-job.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "common.names.fullname" . }}-seeder-{{ now | date "20060102150405" }}
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+spec:
+  ttlSecondsAfterFinished: 6000
+  template:
+    spec:
+      containers:
+        - name: seeder
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}{{ if .Values.image.sha256 }}@sha256:{{ .Values.image.sha256 }}{{ else }}:{{ .Values.image.tag }}{{ end }}"
+          imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+          args:
+            - bash
+            - /app/docker/prod/seeder
+          envFrom:
+            - secretRef:
+                name: {{ include "common.names.fullname" . }}
+      restartPolicy: Never

--- a/charts/openproject/templates/seeder-job.yaml
+++ b/charts/openproject/templates/seeder-job.yaml
@@ -18,4 +18,4 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ include "common.names.fullname" . }}
-      restartPolicy: Never
+      restartPolicy: OnFailure

--- a/charts/openproject/templates/service.yaml
+++ b/charts/openproject/templates/service.yaml
@@ -26,5 +26,6 @@ spec:
     {{- end }}
   selector:
     {{- include "common.labels.matchLabels" . | nindent 4 }}
+    openproject/process: web
 {{- end }}
 ...

--- a/charts/openproject/templates/tests/test-connection.yaml
+++ b/charts/openproject/templates/tests/test-connection.yaml
@@ -16,6 +16,6 @@ spec:
         - '--no-verbose'
         - '--tries=1'
         - '--spider'
-        - '{{ include "common.names.fullname" . }}:{{ .Values.service.ports.http.port }}/health_checks/all'
+        - '{{ include "common.names.fullname" . }}:{{ .Values.service.ports.http.port }}/health_check'
   restartPolicy: "Never"
 ...

--- a/charts/openproject/templates/web-deployment.yaml
+++ b/charts/openproject/templates/web-deployment.yaml
@@ -65,8 +65,7 @@ spec:
                 name: {{ include "common.names.fullname" . }}
           command:
             - bash
-            - -c
-            - 'bundle exec rails runner "require %(timeout); Timeout::timeout(120) do; while true do; puts %(waiting for db); sleep 2; begin; ActiveRecord::Migration.check_pending!; puts %(db ready); exit 0; rescue; end; end; end"'
+            - /app/docker/prod/wait-for-db
       containers:
         - name: "openproject"
           securityContext:

--- a/charts/openproject/templates/web-deployment.yaml
+++ b/charts/openproject/templates/web-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "common.names.fullname" . }}-web
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
+    openproject/process: web
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
@@ -12,6 +13,7 @@ spec:
   selector:
     matchLabels:
       {{- include "common.labels.matchLabels" . | nindent 6 }}
+      openproject/process: web
   template:
     metadata:
       annotations:
@@ -24,6 +26,7 @@ spec:
         checksum/config: {{ values $secretData | sortAlpha | cat | sha256sum }}
       labels:
         {{- include "common.labels.standard" . | nindent 8 }}
+        openproject/process: web
     spec:
       {{- if or .Values.imagePullSecrets .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/openproject/templates/web-deployment.yaml
+++ b/charts/openproject/templates/web-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ include "common.names.fullname" . }}-web
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 spec:
@@ -54,6 +54,19 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "common.names.fullname" . }}
       {{- end }}
+      initContainers:
+        - name: wait-for-db
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}{{ if .Values.image.sha256 }}@sha256:{{ .Values.image.sha256 }}{{ else }}:{{ .Values.image.tag }}{{ end }}"
+          imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+          envFrom:
+            - secretRef:
+                name: {{ include "common.names.fullname" . }}
+          command:
+            - bash
+            - -c
+            - 'bundle exec rails runner "require %(timeout); Timeout::timeout(120) do; while true do; puts %(waiting for db); sleep 2; begin; ActiveRecord::Migration.check_pending!; puts %(db ready); exit 0; rescue; end; end; end"'
       containers:
         - name: "openproject"
           securityContext:

--- a/charts/openproject/templates/web-deployment.yaml
+++ b/charts/openproject/templates/web-deployment.yaml
@@ -48,8 +48,13 @@ spec:
         {{ toYaml . | nindent 8 | trim }}
       {{- end }}
       serviceAccountName: {{ include "common.names.fullname" . }}
-      {{- if .Values.persistence.enabled }}
       volumes:
+      {{- if .Values.egress.tls.rootCA.fileName }}
+        - name: ca-pemstore
+          configMap:
+            name: "{{- .Values.egress.tls.rootCA.configMap }}"
+      {{- end }}
+      {{- if .Values.persistence.enabled }}
         - name: "data"
           persistentVolumeClaim:
             claimName: {{ include "common.names.fullname" . }}
@@ -75,10 +80,21 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ include "common.names.fullname" . }}
-          {{- if .Values.persistence.enabled }}
+          {{- if .Values.egress.tls.rootCA.fileName }}
+          env:
+            - name: SSL_CERT_FILE
+              value: "/etc/ssl/certs/custom-ca.pem"
+          {{- end }}
           volumeMounts:
+          {{- if .Values.persistence.enabled }}
             - name: "data"
               mountPath: "/var/openproject/assets"
+          {{- end }}
+          {{- if .Values.egress.tls.rootCA.fileName }}
+            - name: ca-pemstore
+              mountPath: /etc/ssl/certs/custom-ca.pem
+              subPath: {{ .Values.egress.tls.rootCA.fileName }}
+              readOnly: false
           {{- end }}
           ports:
             {{- range $key, $value := .Values.service.ports }}

--- a/charts/openproject/templates/worker-deployment.yaml
+++ b/charts/openproject/templates/worker-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "common.names.fullname" . }}-worker
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
+    openproject/process: worker
 spec:
   replicas: {{ .Values.backgroundReplicaCount }}
   strategy:
@@ -12,6 +13,7 @@ spec:
   selector:
     matchLabels:
       {{- include "common.labels.matchLabels" . | nindent 6 }}
+      openproject/process: worker
   template:
     metadata:
       annotations:
@@ -24,6 +26,7 @@ spec:
         checksum/config: {{ values $secretData | sortAlpha | cat | sha256sum }}
       labels:
         {{- include "common.labels.standard" . | nindent 8 }}
+        openproject/process: worker
     spec:
       {{- if or .Values.imagePullSecrets .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/openproject/templates/worker-deployment.yaml
+++ b/charts/openproject/templates/worker-deployment.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ include "common.names.fullname" . }}-worker
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.strategy.type }}
+  selector:
+    matchLabels:
+      {{- include "common.labels.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- range $key, $val := .Values.podAnnotations }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
+        # annotate pods with env value checksum so changes trigger re-deployments
+        {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace (include "common.names.fullname" .)) | default dict }}
+        {{- $secretData := (get $secretObj "data") | default dict }}
+        checksum/config: {{ values $secretData | sortAlpha | cat | sha256sum }}
+      labels:
+        {{- include "common.labels.standard" . | nindent 8 }}
+    spec:
+      {{- if or .Values.imagePullSecrets .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range (coalesce .Values.imagePullSecrets .Values.global.imagePullSecrets) }}
+        - name: "{{ . }}"
+        {{- end }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 | trim }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{ toYaml . | nindent 8 | trim }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{ toYaml . | nindent 8 | trim }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{ toYaml . | nindent 8 | trim }}
+      {{- end }}
+      serviceAccountName: {{ include "common.names.fullname" . }}
+      {{- if .Values.persistence.enabled }}
+      volumes:
+        - name: "data"
+          persistentVolumeClaim:
+            claimName: {{ include "common.names.fullname" . }}
+      {{- end }}
+      initContainers:
+        - name: wait-for-db
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}{{ if .Values.image.sha256 }}@sha256:{{ .Values.image.sha256 }}{{ else }}:{{ .Values.image.tag }}{{ end }}"
+          imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+          envFrom:
+            - secretRef:
+                name: {{ include "common.names.fullname" . }}
+          command:
+            - bash
+            - -c
+            - 'bundle exec rails runner "require %(timeout); Timeout::timeout(120) do; while true do; puts %(waiting for db); sleep 2; begin; ActiveRecord::Migration.check_pending!; puts %(db ready); exit 0; rescue; end; end; end"'
+      containers:
+        - name: "openproject"
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}{{ if .Values.image.sha256 }}@sha256:{{ .Values.image.sha256 }}{{ else }}:{{ .Values.image.tag }}{{ end }}"
+          imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+          envFrom:
+            - secretRef:
+                name: {{ include "common.names.fullname" . }}
+          command:
+            - bash
+            - /app/docker/prod/worker
+          {{- if .Values.persistence.enabled }}
+          volumeMounts:
+            - name: "data"
+              mountPath: "/var/openproject/assets"
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/openproject/templates/worker-deployment.yaml
+++ b/charts/openproject/templates/worker-deployment.yaml
@@ -65,8 +65,7 @@ spec:
                 name: {{ include "common.names.fullname" . }}
           command:
             - bash
-            - -c
-            - 'bundle exec rails runner "require %(timeout); Timeout::timeout(120) do; while true do; puts %(waiting for db); sleep 2; begin; ActiveRecord::Migration.check_pending!; puts %(db ready); exit 0; rescue; end; end; end"'
+            - /app/docker/prod/wait-for-db
       containers:
         - name: "openproject"
           securityContext:

--- a/charts/openproject/templates/worker-deployment.yaml
+++ b/charts/openproject/templates/worker-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.backgroundReplicaCount }}
   strategy:
     type: {{ .Values.strategy.type }}
   selector:
@@ -48,8 +48,13 @@ spec:
         {{ toYaml . | nindent 8 | trim }}
       {{- end }}
       serviceAccountName: {{ include "common.names.fullname" . }}
-      {{- if .Values.persistence.enabled }}
       volumes:
+      {{- if .Values.egress.tls.rootCA.fileName }}
+        - name: ca-pemstore
+          configMap:
+            name: "{{- .Values.egress.tls.rootCA.configMap }}"
+      {{- end }}
+      {{- if .Values.persistence.enabled }}
         - name: "data"
           persistentVolumeClaim:
             claimName: {{ include "common.names.fullname" . }}
@@ -75,13 +80,24 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ include "common.names.fullname" . }}
+          {{- if .Values.egress.tls.rootCA.fileName }}
+          env:
+            - name: SSL_CERT_FILE
+              value: "/etc/ssl/certs/custom-ca.pem"
+          {{- end }}
           command:
             - bash
             - /app/docker/prod/worker
-          {{- if .Values.persistence.enabled }}
           volumeMounts:
+          {{- if .Values.persistence.enabled }}
             - name: "data"
               mountPath: "/var/openproject/assets"
+          {{- end }}
+          {{- if .Values.egress.tls.rootCA.fileName }}
+            - name: ca-pemstore
+              mountPath: /etc/ssl/certs/custom-ca.pem
+              subPath: {{ .Values.egress.tls.rootCA.fileName }}
+              readOnly: false
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -91,6 +91,12 @@ ingress:
     #
     secretName: ""
 
+egress:
+  tls:
+    rootCA:
+      configMap: ""
+      fileName: ""
+
 ## Define image setting
 #
 image:
@@ -382,9 +388,13 @@ probes:
     #
     successThreshold: 1
 
-## Number of OpenProject replicas.
+## Number of OpenProject web process replicas.
 #
 replicaCount: 1
+
+## Number of OpenProject background worker process replicas.
+#
+backgroundReplicaCount: 1
 
 ## Configure resource requests and limits.
 ##

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -118,7 +118,7 @@ image:
 
   ## Define image tag.
   ##
-  tag: "12"
+  tag: "13-slim"
 
   ## Define image sha256 - mutual exclusive with image tag.
   ## The sha256 has a higher precedence than


### PR DESCRIPTION
WP [#50645](https://community.openproject.org/projects/devops/work_packages/50645/activity)

This PR uses the `-slim` tag for the used images. To make that work the following things were done:

- [x] create new deployment for worker process
- [x] create batch job for migrating and seeding the database
- [x] introduce init containers for deployments to wait for the database

Depends on https://github.com/opf/openproject/pull/13826.