### PR TITLE
Fix/persistent volume seeder

### DIFF
--- a/charts/openproject/Chart.yaml
+++ b/charts/openproject/Chart.yaml
@@ -5,7 +5,7 @@ description: "A Helm chart for running OpenProject via Kubernetes"
 home: "https://www.openproject.org/"
 icon: "https://www.openproject.org/assets/images/press/openproject-icon-original-color-41055eb6.png"
 type: "application"
-version: "2.0.1"
+version: "2.0.2"
 appVersion: "12"
 maintainers:
   - name: OpenProject

--- a/charts/openproject/templates/seeder-job.yaml
+++ b/charts/openproject/templates/seeder-job.yaml
@@ -8,6 +8,12 @@ spec:
   ttlSecondsAfterFinished: 6000
   template:
     spec:
+      {{- if .Values.persistence.enabled }}
+      volumes:
+        - name: "data"
+          persistentVolumeClaim:
+            claimName: {{ include "common.names.fullname" . }}
+      {{- end }}
       initContainers:
         - name: check-db-ready
           image: postgres:13


### PR DESCRIPTION
The seeder job did not receive the volume claim and was unable to write to the shared volume for e.g., assets created during initialization