### PR TITLE
Use ReadWriteMany as default

### DIFF
--- a/charts/openproject/Chart.yaml
+++ b/charts/openproject/Chart.yaml
@@ -5,7 +5,7 @@ description: "A Helm chart for running OpenProject via Kubernetes"
 home: "https://www.openproject.org/"
 icon: "https://www.openproject.org/assets/images/press/openproject-icon-original-color-41055eb6.png"
 type: "application"
-version: "2.0.2"
+version: "2.0.3"
 appVersion: "12"
 maintainers:
   - name: OpenProject

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -255,7 +255,7 @@ persistence:
   ##                       you want to ensure that only one pod across whole cluster can read that PVC or write to it.
   #
   accessModes:
-    - "ReadWriteOnce"
+    - "ReadWriteMany"
 
   ## Define custom storage annotations:
   ##


### PR DESCRIPTION
We either need an object storage, or depend on ReadWriteMany volumes in order to mount the same volume for worker and web processes