### PR TITLE
Add support for existing persistance claim

### DIFF
--- a/charts/openproject/Chart.yaml
+++ b/charts/openproject/Chart.yaml
@@ -6,7 +6,7 @@ home: "https://www.openproject.org/"
 icon: "https://www.openproject.org/assets/images/press/openproject-icon-original-color-41055eb6.png"
 type: "application"
 appVersion: "13"
-version: "2.4.0"
+version: "2.5.0"
 maintainers:
   - name: OpenProject
     url: https://github.com/opf/helm-charts

--- a/charts/openproject/templates/persistentvolumeclaim.yaml
+++ b/charts/openproject/templates/persistentvolumeclaim.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.persistence.enabled }}
+{{- if not .Values.persistence.existingClaim }}
 ---
 apiVersion: "v1"
 kind: "PersistentVolumeClaim"
@@ -19,4 +20,5 @@ spec:
     requests:
       storage: {{ .Values.persistence.size | quote }}
 ...
+{{- end }}
 {{- end }}

--- a/charts/openproject/templates/seeder-job.yaml
+++ b/charts/openproject/templates/seeder-job.yaml
@@ -12,11 +12,15 @@ spec:
       securityContext:
         {{ omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 | trim }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{ toYaml . | nindent 8 | trim }}
+      {{- end }}
       {{- if .Values.persistence.enabled }}
       volumes:
         - name: "data"
           persistentVolumeClaim:
-            claimName: {{ include "common.names.fullname" . }}
+            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ include "common.names.fullname" . }}{{- end }}
       {{- end }}
       initContainers:
         - name: check-db-ready

--- a/charts/openproject/templates/web-deployment.yaml
+++ b/charts/openproject/templates/web-deployment.yaml
@@ -60,7 +60,7 @@ spec:
       {{- if .Values.persistence.enabled }}
         - name: "data"
           persistentVolumeClaim:
-            claimName: {{ include "common.names.fullname" . }}
+            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ include "common.names.fullname" . }}{{- end }}
       {{- end }}
       initContainers:
         - name: wait-for-db


### PR DESCRIPTION
This PR should be helpful in cases when the volume is managed outside this helm chart (for example, when the volume and PVC are created by Terraform In AWS.)