### PR TITLE
Use revision as suffix in job and add metadata

### DIFF
--- a/charts/openproject/Chart.yaml
+++ b/charts/openproject/Chart.yaml
@@ -6,7 +6,7 @@ home: "https://www.openproject.org/"
 icon: "https://www.openproject.org/assets/images/press/openproject-icon-original-color-41055eb6.png"
 type: "application"
 appVersion: "13"
-version: "2.6.1"
+version: "2.6.2"
 maintainers:
   - name: OpenProject
     url: https://github.com/opf/helm-charts

--- a/charts/openproject/templates/seeder-job.yaml
+++ b/charts/openproject/templates/seeder-job.yaml
@@ -11,6 +11,13 @@ metadata:
 spec:
   ttlSecondsAfterFinished: 6000
   template:
+    metadata:
+      labels:
+        {{- include "common.labels.standard" . | nindent 8 }}
+      {{- with .Values.seederJob.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.podSecurityContext.enabled }}
       securityContext:


### PR DESCRIPTION
Hey OpenProject Team :wave:,

the addition of annotations for the seeder Job were a brilliant idea, cause I need the annotation at the pod to apply NetworkPolicies.

...But the annotation were only available for the Job and not the created Pod - the PR should change this (already tested) :wink: 

