### PR TITLE
Fix whitespace generation in s3 secret

### DIFF
--- a/.changeset/cuddly-pants-play.md
+++ b/.changeset/cuddly-pants-play.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": patch
+---
+
+Fix whitespace generation in s3 secret

--- a/charts/openproject/templates/secret_s3.yaml
+++ b/charts/openproject/templates/secret_s3.yaml
@@ -10,13 +10,13 @@ stringData:
   OPENPROJECT_ATTACHMENTS__STORAGE: fog
   OPENPROJECT_FOG_CREDENTIALS_PROVIDER: AWS
   {{ $secret := (lookup "v1" "Secret" "openproject" .Values.s3.auth.existingSecret) | default (dict "data" dict) -}}
-  OPENPROJECT_FOG_CREDENTIALS_AWS__ACCESS__KEY__ID: {{
+  OPENPROJECT_FOG_CREDENTIALS_AWS__ACCESS__KEY__ID: {{-
     default .Values.s3.auth.accessKeyId (get $secret.data .Values.s3.auth.secretKeys.accessKeyId)
   }}
-  OPENPROJECT_FOG_CREDENTIALS_AWS__SECRET__ACCESS__KEY: {{
+  OPENPROJECT_FOG_CREDENTIALS_AWS__SECRET__ACCESS__KEY: {{-
     default .Values.s3.auth.secretAccessKey (get $secret.data .Values.s3.auth.secretKeys.secretAccessKey)
   }}
-  {{- if .Values.s3.endpoint -}}
+  {{ if .Values.s3.endpoint -}}
   OPENPROJECT_FOG_CREDENTIALS_ENDPOINT: {{ .Values.s3.endpoint }}
   {{- end }}
   OPENPROJECT_FOG_DIRECTORY: {{ .Values.s3.bucketName }}


### PR DESCRIPTION
If you run the chart install with:
`helm upgrade --create-namespace --namespace openproject --install openproject openproject/openproject --dry-run -f values.yaml`

and you have defined s3 in your values.yaml:
```yaml
s3:
  enabled: true
  endpoint: "minio.local"
  auth:
    existingSecret: "minio-credentials"
    secretKeys:
      accessKeyId: "accessKeyId"
      secretAccessKey: "secretAccessKey"
```

it fails with the following error: 
`Helm upgrade failed: YAML parse error on openproject/templates/secret_s3.yaml: error converting YAML to JSON: yaml: line 15: mapping values are not allowed in this context`

this is due to a whitespace formatting error in secret_s3.yaml which this pull request fixes.