### PR TITLE
Fix S3 secret lookup

### DIFF
--- a/.changeset/fix-s3-secret-lookup.md
+++ b/.changeset/fix-s3-secret-lookup.md
@@ -1,0 +1,14 @@
+---
+"@openproject/helm-charts": patch
+---
+
+Fix S3 secret lookup
+
+There were two problems:
+
+1. The namespace was hardcoded
+2. The whitespace trimming was breaking the yaml
+
+Now the lookup will be based on the namespace where the
+release is being deployed, and the whitespace trimming
+has been fixed.

--- a/charts/openproject/templates/secret_s3.yaml
+++ b/charts/openproject/templates/secret_s3.yaml
@@ -9,12 +9,12 @@ metadata:
 stringData:
   OPENPROJECT_ATTACHMENTS__STORAGE: fog
   OPENPROJECT_FOG_CREDENTIALS_PROVIDER: AWS
-  {{ $secret := (lookup "v1" "Secret" "openproject" .Values.s3.auth.existingSecret) | default (dict "data" dict) -}}
-  OPENPROJECT_FOG_CREDENTIALS_AWS__ACCESS__KEY__ID: {{-
-    default .Values.s3.auth.accessKeyId (get $secret.data .Values.s3.auth.secretKeys.accessKeyId)
+  {{ $secret := (lookup "v1" "Secret" .Release.Namespace .Values.s3.auth.existingSecret) | default (dict "data" dict) -}}
+  OPENPROJECT_FOG_CREDENTIALS_AWS__ACCESS__KEY__ID: {{
+    default .Values.s3.auth.accessKeyId (get $secret.data .Values.s3.auth.secretKeys.accessKeyId | b64dec | quote)
   }}
-  OPENPROJECT_FOG_CREDENTIALS_AWS__SECRET__ACCESS__KEY: {{-
-    default .Values.s3.auth.secretAccessKey (get $secret.data .Values.s3.auth.secretKeys.secretAccessKey)
+  OPENPROJECT_FOG_CREDENTIALS_AWS__SECRET__ACCESS__KEY: {{
+    default .Values.s3.auth.secretAccessKey (get $secret.data .Values.s3.auth.secretKeys.secretAccessKey | b64dec | quote)
   }}
   {{ if .Values.s3.endpoint -}}
   OPENPROJECT_FOG_CREDENTIALS_ENDPOINT: {{ .Values.s3.endpoint }}


### PR DESCRIPTION
Fix S3 secret lookup

There were two problems:

1. The namespace was hardcoded
2. The whitespace trimming was breaking the yaml

Now the lookup will be based on the namespace where the
release is being deployed, and the whitespace trimming
has been fixed.