### PR TITLE
Feature: OIDC client id secret and docs

### DIFF
--- a/.changeset/dry-snails-study.md
+++ b/.changeset/dry-snails-study.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": minor
+---
+
+Feature: OIDC client id secret and docs

--- a/charts/openproject/README.md
+++ b/charts/openproject/README.md
@@ -13,7 +13,7 @@ This is the chart for OpenProject itself. It bootstraps an OpenProject instance,
 
 We sign our chart using the [Helm Provenance and Integrity](https://helm.sh/docs/topics/provenance/) functionality. You can find the used public key here
 
-- https://github.com/opf/helm-charts/blob/main/signing.key 
+- https://github.com/opf/helm-charts/blob/main/signing.key
 - https://keys.openpgp.org/vks/v1/by-fingerprint/CB1CA0488A75B7471EA1B087CF56DD6A0AE260E5
 
 We recommend using the [Helm GnuPG plugin](https://github.com/technosophos/helm-gpg). With it you can manually verify the signature like this:
@@ -157,56 +157,6 @@ Either increase the cluster's resources to have at least 4 CPUs or install the O
 --set resources.limits.cpu=2
 ```
 
-
-
-## OpenShift
-
-For OpenProject to work in OpenShift without further adjustments,
-you need to use the following pod security context.
-
-```
-podSecurityContext:
-  supplementalGroups: [1000]
-  fsGroup: null
-```
-
-By default OpenProject requests `fsGroup: 1000` in the pod security context.
-This is not allowed by default. You have to allow it using
-a custom SCC (Security Context Constraint) in the cluster.
-
-The use of `supplementalGroups` is not necessary if you request the correct UID in the security context.
-
-```
-securityContext:
-  runAsUser: 1000
-  runAsGroup: 1000
-```
-
-But this will not be allowed by default either. So the easiest way is the use of the `podSecurityContext` shown above.
-
-Due to the default restrictions in OpenShift there may also be issues running
-PostgreSQL and memcached. Again, you may have to create an SCC to fix this
-or adjust the policies in the subcharts accordingly.
-
-Assuming no further options for both, simply disabling the security context values to use the default works as well.
-
-```
-postgresql:
-  primary:
-    containerSecurityContext:
-      enabled: false
-    podSecurityContext:
-      enabled: false
-
-memcached:
-  containerSecurityContext:
-    enabled: false
-  podSecurityContext:
-    enabled: false
-```
-
-
-
 ## Development
 
 To install or update from this directory run the following command.
@@ -273,4 +223,50 @@ To make OpenProject use this CA for outgoing TLS connection, set the following o
 ```
   --set egress.tls.rootCA.configMap=ca-pemstore \
   --set egress.tls.rootCA.fileName=rootCA.pem
+```
+
+## OpenShift
+
+For OpenProject to work in OpenShift without further adjustments,
+you need to use the following pod security context.
+
+```
+podSecurityContext:
+  supplementalGroups: [1000]
+  fsGroup: null
+```
+
+By default OpenProject requests `fsGroup: 1000` in the pod security context.
+This is not allowed by default. You have to allow it using
+a custom SCC (Security Context Constraint) in the cluster.
+
+The use of `supplementalGroups` is not necessary if you request the correct UID in the security context.
+
+```
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+```
+
+But this will not be allowed by default either. So the easiest way is the use of the `podSecurityContext` shown above.
+
+Due to the default restrictions in OpenShift there may also be issues running
+PostgreSQL and memcached. Again, you may have to create an SCC to fix this
+or adjust the policies in the subcharts accordingly.
+
+Assuming no further options for both, simply disabling the security context values to use the default works as well.
+
+```
+postgresql:
+  primary:
+    containerSecurityContext:
+      enabled: false
+    podSecurityContext:
+      enabled: false
+
+memcached:
+  containerSecurityContext:
+    enabled: false
+  podSecurityContext:
+    enabled: false
 ```

--- a/charts/openproject/README.md
+++ b/charts/openproject/README.md
@@ -225,6 +225,82 @@ To make OpenProject use this CA for outgoing TLS connection, set the following o
   --set egress.tls.rootCA.fileName=rootCA.pem
 ```
 
+## Secrets
+
+There are various sensitive credentials used by the chart.
+While they can be provided directly in the values (e.g. `--set postgresql.auth.password`),
+it is recommended to store them in secrets instead.
+
+You can create a new secret like this:
+
+```
+kubectl -n openproject create secret generic <name>
+```
+
+You can then edit the secret to add the credentials via the following.
+
+```
+kubectl -n openproject edit secret <name>
+```
+
+The newly created secret will look something like this:
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: "2024-01-10T09:36:09Z"
+  name: <name>
+  namespace: openproject
+  resourceVersion: "1074377"
+  uid: ff6538cd-f8cb-418f-8cee-bd1e20d96d24
+type: Opaque
+```
+
+To add the actual content, you can simply add `stringData:` to the end of it and save it.
+
+The keys which are looked up inside the secret data can be changed from their defaults in the values as well. This is the same in all cases where next to `existingSecret` you can also set `secretKeys`.
+
+In the following sections we give examples for what this may look like using the default keys for the credentials used by OpenProject.
+
+### PostgreSQL
+
+```yaml
+stringData:
+  postgres-password: postgresPassword
+  password: userPassword
+```
+
+If you have an existing secret where the keys are not `postgres-password` and `password`, you can customize the used keys as mentioned above.
+
+For instance:
+
+```bash
+helm upgrade --create-namespace --namespace openproject --install openproject \
+  --set postgresql.auth.existingSecret=mysecret \
+  --set postgresql.auth.secretKeys.adminPasswordKey=adminpw \
+  --set postgresql.auth.secretKeys.userPasswordKey=userpw
+```
+
+This can be customized for the the credentials in the following sections too in the same fashion.
+You can look up the respective options in the [`values.yaml`](./values.yaml) file.
+
+### OIDC (OpenID Connect)
+
+```yaml
+stringData:
+  clientId: 7c6cc104-1d07-4a9f-b3fb-017da8577cec
+  clientSecret: Sf78Q~H14O7F2_EOS4NsLoxu-ayOm42i~MljMb44
+```
+
+### S3
+
+```yaml
+stringData:
+  accessKeyId: AKIAXDF2JNZRBFQIRTKA
+  secretAccessKey: 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
+```
+
 ## OpenShift
 
 For OpenProject to work in OpenShift without further adjustments,

--- a/charts/openproject/templates/secret_oidc.yaml
+++ b/charts/openproject/templates/secret_oidc.yaml
@@ -11,10 +11,12 @@ stringData:
   {{ $oidc_prefix := printf "OPENPROJECT_OPENID__CONNECT_%s" (upper .Values.openproject.oidc.provider) }}
   {{ $oidc_prefix }}_DISPLAY__NAME: {{ .Values.openproject.oidc.displayName | quote }}
   {{ $oidc_prefix }}_HOST: {{ .Values.openproject.oidc.host | quote }}
-  {{ $oidc_prefix }}_IDENTIFIER: {{ .Values.openproject.oidc.identifier | quote }}
   {{/* Fall back to '_' as secret name if the name is not given. This way `lookup` will return null (since secrets with this name will and cannot exist) which it doesn't with an empty string. */}}
   {{ $secret := (lookup "v1" "Secret" .Release.Namespace (default "_" .Values.openproject.oidc.existingSecret)) | default (dict "data" dict) -}}
-  {{ $oidc_prefix }}_SECRET: {{ 
+  {{ $oidc_prefix }}_IDENTIFIER: {{
+    default .Values.openproject.oidc.identifier (get $secret.data .Values.openproject.oidc.secretKeys.identifier | b64dec) | quote
+  }}
+  {{ $oidc_prefix }}_SECRET: {{
     default .Values.openproject.oidc.secret (get $secret.data .Values.openproject.oidc.secretKeys.secret | b64dec) | quote
   }}
   {{ $oidc_prefix }}_AUTHORIZATION__ENDPOINT: {{ .Values.openproject.oidc.authorizationEndpoint | quote }}

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -296,7 +296,8 @@ openproject:
 
     ## In case your secret does not use the default keys in the secret, you can adjust them here.
     secretKeys:
-      secret: "oidcSecret"
+      identifier: "clientId"
+      secret: "clientSecret"
 
   ## Modify PostgreSQL statement timout.
   ## Increase in case you get errors such as "ERROR: canceling statement due to statement timeout".


### PR DESCRIPTION
Since we allow storing not only the secret access key but also the access key ID in the case of S3 I figured we should also do the same for OIDC so one can have both client ID and secret in the same place.

I have also amended the documentation to make it easier for beginners to create the respective secrets.