### PR TITLE
Allows usage of sealed-secret for oidc `identifier` and `secret` values when helm template 'lookup' is not available

### DIFF
--- a/.changeset/gentle-eyes-rest.md
+++ b/.changeset/gentle-eyes-rest.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": minor
+---
+
+Allow sealed secrets for OIDC secrets

--- a/charts/openproject/README.md
+++ b/charts/openproject/README.md
@@ -307,6 +307,16 @@ stringData:
   clientSecret: Sf78Q~H14O7F2_EOS4NsLoxu-ayOm42i~MljMb44
 ```
 
+
+
+**Sealed secrets**
+
+```bash
+kubectl create secret generic openproject-oidc-secret-sealed --from-literal=OPENPROJECT_OPENID__CONNECT_PROVIDERHERE_IDENTIFIER=xxxxx --from-literal=OPENPROJECT_OPENID__CONNECT_PROVIDERHERE_SECRET=xxxxx --dry-run=client -o yaml | kubeseal ...
+```
+
+Set `openproject.oidc.extraOidcSealedSecret="openproject-oidc-secret-sealed"` in your values.
+
 ### S3
 
 ```yaml

--- a/charts/openproject/templates/_helpers.tpl
+++ b/charts/openproject/templates/_helpers.tpl
@@ -115,6 +115,10 @@ envFrom:
   - secretRef:
       name: {{ .Values.openproject.extraEnvVarsSecret }}
   {{- end }}
+  {{- if .Values.openproject.oidc.extraOidcSealedSecret }}
+  - secretRef:
+      name: {{ .Values.openproject.oidc.extraOidcSealedSecret }}
+  {{- end }}
 {{- end }}
 
 {{- define "openproject.env" -}}

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -301,6 +301,13 @@ openproject:
       identifier: "clientId"
       secret: "clientSecret"
 
+    # Allows usage of sealed-secret for `identifier` and `secret` values.
+    # Special use case for use in setups where heml template `lookup` function is not available.
+    # Ref: https://github.com/argoproj/argo-cd/issues/5202
+    #
+    # extraOidcSealedSecret:
+    #
+
   ## Modify PostgreSQL statement timout.
   ## Increase in case you get errors such as "ERROR: canceling statement due to statement timeout".
   ##

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -305,8 +305,7 @@ openproject:
     # Special use case for use in setups where heml template `lookup` function is not available.
     # Ref: https://github.com/argoproj/argo-cd/issues/5202
     #
-    # extraOidcSealedSecret:
-    #
+    extraOidcSealedSecret:
 
   ## Modify PostgreSQL statement timout.
   ## Increase in case you get errors such as "ERROR: canceling statement due to statement timeout".

--- a/spec/charts/openproject/oidc_spec.rb
+++ b/spec/charts/openproject/oidc_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe 'oidc configuration' do
+  let(:template) { HelmTemplate.new(default_values) }
+
+  let(:definitions) {
+    {
+      'Deployment/optest-openproject-web' => 'openproject',
+      'Deployment/optest-openproject-worker' => 'openproject',
+      /optest-openproject-seeder/ => 'seeder'
+    }
+  }
+
+  context 'when setting extraOidcSealedSecret' do
+    let(:default_values) do
+      HelmTemplate.with_defaults(<<~YAML
+        openproject:
+          oidc:
+            extraOidcSealedSecret: openproject-oidc-secret-sealed
+      YAML
+      )
+    end
+
+    it 'adds that secret ref to relevant deployments', :aggregate_failures do
+      definitions.each do |item, container|
+        expect(template.secret_ref(item, container, 'openproject-oidc-secret-sealed'))
+          .to be_a(Hash)
+      end
+    end
+  end
+
+  context 'when setting no imagePullSecrets' do
+    let(:default_values) do
+      {}
+    end
+
+    it 'adds the default secrets', :aggregate_failures do
+      definitions.each do |item, container|
+        expect(template.secret_ref(item, container, 'openproject-oidc-secret-sealed'))
+          .to be_nil
+
+        expect(template.env_from(item, container))
+          .to include(
+                { "secretRef" => { "name" => "optest-openproject-core" } },
+                { "secretRef" => { "name" => "optest-openproject-memcached" } }
+              )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello,

Please consider this as a enhancement suggestion as we are aware that this is not a bug from your side.

Please find our detailed reasoning for this below if needed as additional explanation.

This should allow usage in .Values.openproject.oidc.extraOidcSealedSecret pointing to custom generated sealed secret to load following values:
```
  OPENPROJECT_OPENID__CONNECT_PROVIDERHERE_IDENTIFIER
  OPENPROJECT_OPENID__CONNECT_PROVIDERHERE_SECRET
```  
As this separates IDENTIFIER and SECRET in sealed-secret, while rest of the OIDC configuration values are stored in Secret.

#### What was our goal?
To have OpenProject Helm charts sealed-secrets loaded for OIDC working without using of `lookup` function ([ArgoCD related issue](https://github.com/argoproj/argo-cd/issues/5202))

#### How we achieved this?
Sealed-secret was created first:
```
 # kubectl create secret generic openproject-oidc-secret-sealed --from-literal=OPENPROJECT_OPENID__CONNECT_PROVIDERHERE_IDENTIFIER=xxxxx --from-literal=OPENPROJECT_OPENID__CONNECT_PROVIDERHERE_SECRET=xxxxx --dry-run=client -o yaml | kubeseal ...
``` 

When secret is manually created we noted that important part to note is (upper .Values.openproject.oidc.provider) to match other OPENPROJECT_OPENID__CONNECT_* environment vars.

So if oidc.provider is 'providerhere' keys for `kubectl create secret` are:
```
  OPENPROJECT_OPENID__CONNECT_PROVIDERHERE_IDENTIFIER
  OPENPROJECT_OPENID__CONNECT_PROVIDERHERE_SECRET
```
In this case we got our two desired values in sealed secret.

Now we need to load them. I have noticed that there is one `extraEnvVarsSecret` not used in values.yaml:
https://github.com/opf/helm-charts/blob/main/charts/openproject/values.yaml#L261

It also loads this `extraEnvVarsSecret` secret at just the right spot:
https://github.com/opf/helm-charts/blob/main/charts/openproject/templates/_helpers.tpl#L114C1-L117C13

Afterwards, everything was loaded properly when I performed test as suggested earlier. As well from browser and in the admin area it shows/loads proper values.

Thank you and have a great day!