### PR TITLE
allow setting the storageClass for /tmp and /app/tmp volumes

### DIFF
--- a/.changeset/gorgeous-snakes-drum.md
+++ b/.changeset/gorgeous-snakes-drum.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": minor
+---
+
+allow setting a storageClass for /tmp and /app/tmp volumes

--- a/.changeset/gorgeous-snakes-drum.md
+++ b/.changeset/gorgeous-snakes-drum.md
@@ -2,4 +2,4 @@
 "@openproject/helm-charts": minor
 ---
 
-allow setting a storageClass for /tmp and /app/tmp volumes
+- allow setting `tmpStorageClassName` for /tmp and /app/tmp volumes

--- a/charts/openproject/templates/_helpers.tpl
+++ b/charts/openproject/templates/_helpers.tpl
@@ -93,6 +93,9 @@ securityContext:
     volumeClaimTemplate:
       spec:
         accessModes: ["ReadWriteOnce"]
+        {{- if or .Values.persistence.tmpStorageClassName .Values.persistence.storageClassName }}
+        storageClassName: {{ coalesce .Values.persistence.tmpStorageClassName .Values.persistence.storageClassName }}
+        {{- end }}
         resources:
           requests:
             storage: {{ .Values.openproject.tmpVolumesStorage }}
@@ -103,6 +106,9 @@ securityContext:
     volumeClaimTemplate:
       spec:
         accessModes: ["ReadWriteOnce"]
+        {{- if or .Values.persistence.tmpStorageClassName .Values.persistence.storageClassName }}
+        storageClassName: {{ coalesce .Values.persistence.tmpStorageClassName .Values.persistence.storageClassName }}
+        {{- end }}
         resources:
           requests:
             storage: {{ .Values.openproject.tmpVolumesStorage }}

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -379,6 +379,9 @@ persistence:
   ## Define the class of PV.
   storageClassName:
 
+  ## Define the class of PV for the tmpVolumes.
+  tmpStorageClassName:
+
 ## Whether to use an S3-compatible object storage to store OpenProject attachments.
 ## If this is enabled, files will NOT be stored in the mounted volume configured in `persistence` above.
 ## The volume will not be used at all, so it `persistence.enabled` should be set to `false` in this case.


### PR DESCRIPTION
charts/openproject/templates/_helpers.tpl: use .Values.persistence.storageClassName for /tmp and /app/tmp volumes, if it is defined