### PR TITLE
Allow users to set the openproject host name without using the ingress

### DIFF
--- a/.changeset/sweet-laws-draw.md
+++ b/.changeset/sweet-laws-draw.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": patch
+---
+
+Allow users to set the openproject host name without using the ingress

--- a/charts/openproject/templates/secret_core.yaml
+++ b/charts/openproject/templates/secret_core.yaml
@@ -23,6 +23,8 @@ stringData:
   OPENPROJECT_SEED_LOCALE: {{ .Values.openproject.seed_locale | quote }}
   {{- if .Values.ingress.enabled }}
   OPENPROJECT_HOST__NAME: {{ .Values.openproject.host | default .Values.ingress.host | quote }}
+  {{- else }}
+  OPENPROJECT_HOST__NAME: {{ .Values.openproject.host | quote }}
   {{- end }}
   OPENPROJECT_HSTS: {{ .Values.openproject.hsts | quote }}
   OPENPROJECT_RAILS__CACHE__STORE: {{ .Values.openproject.cache.store | quote }}

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -258,7 +258,7 @@ openproject:
   #
   https: true
 
-  ## Define the host, defaults to value of "ingress.host".
+  ## Define the host, defaults to value of "ingress.host" when ingress is enabled.
   #
   host:
 


### PR DESCRIPTION
Right now, you must have the ingress enabled in order to set the hostname of openproject. This change to the secret core allows the host to specified host value even when ingress is disabled. This is beneficial to users who are using the Gateway API HTTPRoutes instead of traditional Ingresses