### PR TITLE
Allow specified ipaddress for loadBalancerIP

### DIFF
--- a/.changeset/beige-wombats-argue.md
+++ b/.changeset/beige-wombats-argue.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": minor
+---
+
+Allow specified ipaddress for loadBalancerIP

--- a/charts/openproject/templates/service.yaml
+++ b/charts/openproject/templates/service.yaml
@@ -8,6 +8,9 @@ metadata:
     {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if eq .Values.service.type "LoadBalancer" }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP | quote }}
+  {{- end }}
   {{- if .Values.service.sessionAffinity.enabled }}
   sessionAffinity: "ClientIP"
   sessionAffinityConfig:

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -650,6 +650,12 @@ service:
   #
   type: "ClusterIP"
 
+  ## Specify the external IP address for the LoadBalancer service. If your cloud provider supports
+  ## specifying a static IP for the load balancer, you can set it here.
+  ## Example:
+  ## loadBalancerIP: "172.16.0.1"
+  loadBalancerIP: ""
+
   ## Define the ports of Service.
   ## You can set the port value to an arbitrary value, it will map the container port by name.
   ##


### PR DESCRIPTION
Hello :smile:
If service type is LoadBalanser, It can specify LoadBalanserIP.