### PR TITLE
make sure removed secret values are actually removed

### DIFF
--- a/.changeset/strange-pillows-happen.md
+++ b/.changeset/strange-pillows-happen.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": minor
+---
+
+make sure removed secret values are actually removed

--- a/charts/openproject/templates/secret_environment.yaml
+++ b/charts/openproject/templates/secret_environment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: "{{ include "common.names.fullname" . }}-environment"
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
+data: # reset data to make sure only keys defined below remain
 stringData:
   # Additional environment variables
   {{- range $key, $value := .Values.environment }}

--- a/charts/openproject/templates/secret_memcached.yaml
+++ b/charts/openproject/templates/secret_memcached.yaml
@@ -6,6 +6,7 @@ metadata:
   name: "{{ include "common.names.fullname" . }}-memcached"
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
+data: # reset data to make sure only keys defined below remain
 stringData:
   {{- if .Values.memcached.bundled }}
   OPENPROJECT_CACHE__MEMCACHE__SERVER: "{{ .Release.Name }}-memcached:11211"

--- a/charts/openproject/templates/secret_oidc.yaml
+++ b/charts/openproject/templates/secret_oidc.yaml
@@ -6,6 +6,7 @@ metadata:
   name: "{{ include "common.names.fullname" . }}-oidc"
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
+data: # reset data to make sure only keys defined below remain
 stringData:
   # OpenID Connect settings
   {{ $oidc_prefix := printf "OPENPROJECT_OPENID__CONNECT_%s" (upper .Values.openproject.oidc.provider) }}

--- a/charts/openproject/templates/secret_s3.yaml
+++ b/charts/openproject/templates/secret_s3.yaml
@@ -6,6 +6,7 @@ metadata:
   name: "{{ include "common.names.fullname" . }}-s3"
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
+data: # reset data to make sure only keys defined below remain
 stringData:
   OPENPROJECT_ATTACHMENTS__STORAGE: fog
   OPENPROJECT_FOG_CREDENTIALS_PROVIDER: AWS


### PR DESCRIPTION
stringData is always merged with the data of the existing secret

with this explicit reset values removed from, say, the environment value will not be removed, which is unexpected