### PR TITLE
feat(openproject): Add extraVolumes and extraVolumeMounts option

### DIFF
--- a/.changeset/early-moons-fold.md
+++ b/.changeset/early-moons-fold.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": minor
+---
+
+Allow definition of extraVolumes and extraVolumeMounts

--- a/.changeset/manual-changeset-118.md
+++ b/.changeset/manual-changeset-118.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": minor
+---
+
+Add extraVolumes and extraVolumeMounts option

--- a/charts/openproject/templates/_helpers.tpl
+++ b/charts/openproject/templates/_helpers.tpl
@@ -18,6 +18,24 @@ imagePullSecrets:
 {{- end -}}
 
 {{/*
+Returns extra volume definitons when defined as values.extraVolumes
+*/}}
+{{- define "openproject.extraVolumes" -}}
+{{- if .Values.extraVolumes }}
+{{ include "common.tplvalues.render" (dict "value" .Values.extraVolumes  "context" .) }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Returns extra volume mounts definitons when defined as values.extraVolumeMounts
+*/}}
+{{- define "openproject.extraVolumeMounts" -}}
+{{- if .Values.extraVolumeMounts }}
+{{ include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" .) }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Yields the configured container security context if enabled.
 
 Allows writing to the container file system in development mode

--- a/charts/openproject/templates/seeder-job.yaml
+++ b/charts/openproject/templates/seeder-job.yaml
@@ -33,9 +33,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ include "common.names.fullname" . }}{{- end }}
         {{- end }}
-        {{- if .Values.extraVolumes }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes  "context" .) | nindent 8 }}
-        {{- end }}
+        {{- include "openproject.extraVolumes" . | indent 8 }}
       initContainers:
         - name: check-db-ready
           image: "{{ .Values.initdb.image.registry }}/{{ .Values.initdb.image.repository }}:{{ .Values.initdb.image.tag }}"
@@ -69,8 +67,6 @@ spec:
             - name: "data"
               mountPath: "/var/openproject/assets"
             {{- end }}
-            {{- if .Values.extraVolumeMounts }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" .) | nindent 12 }}
-            {{- end }}
+            {{- include "openproject.extraVolumeMounts" . | indent 12 }}
           {{- include "openproject.containerSecurityContext" . | indent 10 }}
       restartPolicy: OnFailure

--- a/charts/openproject/templates/seeder-job.yaml
+++ b/charts/openproject/templates/seeder-job.yaml
@@ -33,6 +33,9 @@ spec:
           persistentVolumeClaim:
             claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ include "common.names.fullname" . }}{{- end }}
         {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes  "context" .) | nindent 8 }}
+        {{- end }}
       initContainers:
         - name: check-db-ready
           image: "{{ .Values.initdb.image.registry }}/{{ .Values.initdb.image.repository }}:{{ .Values.initdb.image.tag }}"
@@ -65,6 +68,9 @@ spec:
             {{- if .Values.persistence.enabled }}
             - name: "data"
               mountPath: "/var/openproject/assets"
+            {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" .) | nindent 12 }}
             {{- end }}
           {{- include "openproject.containerSecurityContext" . | indent 10 }}
       restartPolicy: OnFailure

--- a/charts/openproject/templates/web-deployment.yaml
+++ b/charts/openproject/templates/web-deployment.yaml
@@ -52,9 +52,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ include "common.names.fullname" . }}{{- end }}
         {{- end }}
-        {{- if .Values.extraVolumes }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes  "context" .) | nindent 8 }}
-        {{- end }}
+        {{- include "openproject.extraVolumes" . | indent 8 }}
       initContainers:
         - name: wait-for-db
           {{- include "openproject.containerSecurityContext" . | indent 10 }}
@@ -91,9 +89,7 @@ spec:
               subPath: {{ .Values.egress.tls.rootCA.fileName }}
               readOnly: false
             {{- end }}
-            {{- if .Values.extraVolumeMounts }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" .) | nindent 12 }}
-            {{- end }}
+            {{- include "openproject.extraVolumeMounts" . | indent 12 }}
           ports:
             {{- range $key, $value := .Values.service.ports }}
             - name: {{ $key }}

--- a/charts/openproject/templates/web-deployment.yaml
+++ b/charts/openproject/templates/web-deployment.yaml
@@ -52,6 +52,9 @@ spec:
           persistentVolumeClaim:
             claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ include "common.names.fullname" . }}{{- end }}
         {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes  "context" .) | nindent 8 }}
+        {{- end }}
       initContainers:
         - name: wait-for-db
           {{- include "openproject.containerSecurityContext" . | indent 10 }}
@@ -87,6 +90,9 @@ spec:
               mountPath: /etc/ssl/certs/custom-ca.pem
               subPath: {{ .Values.egress.tls.rootCA.fileName }}
               readOnly: false
+            {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" .) | nindent 12 }}
             {{- end }}
           ports:
             {{- range $key, $value := .Values.service.ports }}

--- a/charts/openproject/templates/worker-deployment.yaml
+++ b/charts/openproject/templates/worker-deployment.yaml
@@ -54,9 +54,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "common.names.fullname" . }}
         {{- end }}
-        {{- if .Values.extraVolumes }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes  "context" .) | nindent 8 }}
-        {{- end }}
+        {{- include "openproject.extraVolumes" . | indent 8 }}
       initContainers:
         - name: wait-for-db
           {{- include "openproject.containerSecurityContext" . | indent 10 }}
@@ -95,9 +93,7 @@ spec:
               subPath: {{ .Values.egress.tls.rootCA.fileName }}
               readOnly: false
             {{- end }}
-            {{- if .Values.extraVolumeMounts }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" .) | nindent 12 }}
-            {{- end }}
+            {{- include "openproject.extraVolumeMounts" . | indent 12 }}
           resources:
             {{- coalesce $workerValues.resources .Values.resources | toYaml | nindent 12 }}
 {{- end }}

--- a/charts/openproject/templates/worker-deployment.yaml
+++ b/charts/openproject/templates/worker-deployment.yaml
@@ -43,7 +43,7 @@ spec:
       {{- include "openproject.podSecurityContext" . | indent 6 }}
       serviceAccountName: {{ include "common.names.fullname" . }}
       volumes:
-        {{- include "openproject.tmpVolumeSpec" . | indent 8 }}                     
+        {{- include "openproject.tmpVolumeSpec" . | indent 8 }}
         {{- if .Values.egress.tls.rootCA.fileName }}
         - name: ca-pemstore
           configMap:
@@ -53,6 +53,9 @@ spec:
         - name: "data"
           persistentVolumeClaim:
             claimName: {{ include "common.names.fullname" . }}
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes  "context" .) | nindent 8 }}
         {{- end }}
       initContainers:
         - name: wait-for-db
@@ -91,6 +94,9 @@ spec:
               mountPath: /etc/ssl/certs/custom-ca.pem
               subPath: {{ .Values.egress.tls.rootCA.fileName }}
               readOnly: false
+            {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" .) | nindent 12 }}
             {{- end }}
           resources:
             {{- coalesce $workerValues.resources .Values.resources | toYaml | nindent 12 }}

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -37,6 +37,13 @@ affinity: {}
 #
 environment: {}
 
+# Optionally specify an extra list of additional volumes.
+extraVolumes: []
+
+# Optionally specify an extra list of additional volumeMounts.
+extraVolumeMounts: []
+
+
 ## Provide a name to substitute for the full names of resources.
 #
 fullnameOverride: ""

--- a/spec/charts/openproject/extra_volumes_spec.rb
+++ b/spec/charts/openproject/extra_volumes_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe 'extraVolumes and extraVolumeMounts configuration' do
+  let(:template) { HelmTemplate.new(default_values) }
+
+  let(:definitions) {
+    {
+      'Deployment/optest-openproject-web' => 'openproject',
+      'Deployment/optest-openproject-worker-default' => 'openproject',
+      /optest-openproject-seeder/ => 'seeder'
+    }
+  }
+
+  context 'when setting extraVolumes ' do
+    let(:default_values) do
+      HelmTemplate.with_defaults(<<~YAML
+        extraVolumes:
+          - name: "trusted-cert-secret-volume"
+            secret:
+              secretName: "my-certificates-ca-tls"
+              items:
+                - key: "ca.crt"
+                  path: "ca-certificates.crt"
+        extraVolumeMounts:
+          - name: "trusted-cert-secret-volume"
+            mountPath: "/etc/ssl/certs/ca-certificates.crt"
+            subPath: "ca-certificates.crt"
+      YAML
+      )
+    end
+
+    it 'Populates those volume definitions for all deployments', :aggregate_failures do
+      definitions.each do |item, container_ref|
+        volume = template.find_volume(item, "trusted-cert-secret-volume")
+        expect(volume).not_to be_nil
+        expect(volume['secret']['secretName']).to eq("my-certificates-ca-tls")
+        expect(volume['secret']['items'][0]['key']).to eq("ca.crt")
+        expect(volume['secret']['items'][0]['path']).to eq("ca-certificates.crt")
+
+        container = template.find_container(item, container_ref)
+        mount = container.dig('volumeMounts').detect { |mount| mount["name"] == "trusted-cert-secret-volume" }
+        expect(mount).not_to be_nil
+      end
+    end
+  end
+
+  context 'when setting no imagePullSecrets' do
+    let(:default_values) do
+      {}
+    end
+
+    it 'Populates annotations for all deployments', :aggregate_failures do
+      definitions.each do |item, container_ref|
+        volume = template.find_volume(item, "trusted-cert-secret-volume")
+        expect(volume).to be_nil
+
+        container = template.find_container(item, container_ref)
+        mount = container.dig('volumeMounts').detect { |mount| mount["name"] == "trusted-cert-secret-volume" }
+        expect(mount).to be_nil
+
+      end
+    end
+  end
+end

--- a/spec/helm_template.rb
+++ b/spec/helm_template.rb
@@ -15,9 +15,9 @@ class HelmTemplate
   end
 
   def debug(values, chart, release_name, extra_args = '')
-    @values  = values
+    @values = values
     result = Open3.capture3("helm template --debug #{release_name} . #{extra_args} -f -",
-                            chdir: File.join(__dir__,  '..', 'charts', chart),
+                            chdir: File.join(__dir__, '..', 'charts', chart),
                             stdin_data: YAML.dump(values))
     @stdout, @stderr, @exit_code = result
     # handle common failures when helm or chart not setup properly
@@ -26,13 +26,23 @@ class HelmTemplate
     end
 
     # load the complete output's YAML documents into an array
-    yaml = YAML.load_stream(@stdout)
-    # filter out any empty YAML documents (nil)
-    yaml.select!{ |x| !x.nil? }
-    # create an indexed Hash keyed on Kind/metdata.name
-    @mapped = yaml.to_h  { |doc|
-      [ "#{doc['kind']}/#{doc['metadata']['name']}" , doc ]
-    }
+    begin
+      yaml = YAML.load_stream(@stdout)
+      # filter out any empty YAML documents (nil)
+      yaml.select! { |x| !x.nil? }
+      # create an indexed Hash keyed on Kind/metdata.name
+    @mapped = yaml.to_h { |doc|
+        ["#{doc['kind']}/#{doc['metadata']['name']}", doc]
+      }
+    rescue => e
+      warn "Failed to parse Helm template output: #{e.message}"
+      warn @stdout
+      raise e
+    end
+  end
+
+  def plain
+    @stdout
   end
 
   def [](arg)
@@ -52,37 +62,41 @@ class HelmTemplate
   end
 
   def volumes(item)
-    @mapped.dig(item,'spec','template','spec','volumes')
+    template_spec(item)
+      .dig('volumes')
   end
 
   def labels(item)
-    @mapped.dig(item,'metadata','labels')
+    @mapped.dig(mapped_key(item), 'metadata', 'labels')
   end
 
   def template_labels(item)
     # only one of the following should return results
-    @mapped.dig(item, 'spec', 'template', 'metadata', 'labels') ||
-      @mapped.dig(item, 'spec', 'jobTemplate', 'spec', 'template', 'metadata', 'labels')
+    @mapped.dig(mapped_key(item), 'spec', 'template', 'metadata', 'labels') ||
+      @mapped.dig(mapped_key(item), 'spec', 'jobTemplate', 'spec', 'template', 'metadata', 'labels')
   end
 
   def annotations(item)
-    @mapped.dig(item, 'metadata', 'annotations')
+    @mapped.dig(mapped_key(item), 'metadata', 'annotations')
   end
 
   def template_annotations(item)
     # only one of the following should return results
-    @mapped.dig(item, 'spec', 'template', 'metadata', 'annotations') ||
-      @mapped.dig(item, 'spec', 'jobTemplate', 'spec', 'template', 'metadata', 'annotations')
+    @mapped.dig(mapped_key(item), 'spec', 'template', 'metadata', 'annotations') ||
+      @mapped.dig(mapped_key(item), 'spec', 'jobTemplate', 'spec', 'template', 'metadata', 'annotations')
+  end
+
+  def mapped_key(item)
+    case item
+    when Regexp
+       keys.find { |k| k.match?(item) }
+    else
+      item
+    end
   end
 
   def template_spec(item)
-    case item
-    when Regexp
-      key = keys.find { |k| k.match?(item) }
-      @mapped.dig(key, 'spec', 'template', 'spec')
-    else
-      @mapped.dig(item, 'spec', 'template', 'spec')
-    end
+    @mapped.dig(mapped_key(item), 'spec', 'template', 'spec')
   end
 
   def find_volume(item, volume_name)
@@ -93,7 +107,7 @@ class HelmTemplate
 
   def get_projected_secret(item, mount, secret)
     # locate first instance of projected secret by name
-    secrets = find_volume(item,mount)
+    secrets = find_volume(item, mount)
     secrets['projected']['sources'].keep_if do |s|
       s['secret']['name'] == secret if s.has_key?('secret')
     end
@@ -104,12 +118,12 @@ class HelmTemplate
   end
 
   def find_projected_secret(item, mount, secret)
-    secret = get_projected_secret(item,mount,secret)
+    secret = get_projected_secret(item, mount, secret)
     !secret.nil?
   end
 
   def find_projected_secret_key(item, mount, secret, key)
-    secret = get_projected_secret(item,mount,secret)
+    secret = get_projected_secret(item, mount, secret)
 
     result = nil
 
@@ -164,16 +178,16 @@ class HelmTemplate
   def env_named(item, container_name, key, init = false)
     find_container(item, container_name, init)
       .dig('env')
-      .detect { |hash| hash['name'] == key}
+      .detect { |hash| hash['name'] == key }
   end
 
-  def projected_volume_sources(item,volume_name)
-    find_volume(item,volume_name)
-      &.dig('projected','sources')
+  def projected_volume_sources(item, volume_name)
+    find_volume(item, volume_name)
+      &.dig('projected', 'sources')
   end
 
   def resources_by_kind(kind)
-    @mapped.select{ |_, hash| hash['kind'] == kind }
+    @mapped.select { |_, hash| hash['kind'] == kind }
   end
 
   def exit_code


### PR DESCRIPTION
This PR adds templates for additional volumes and their mounts in deployments/jobs. This is useful, when f.e. the truststore should be changed:

```yaml
extraVolumes:
  - name: "trusted-cert-secret-volume"
    secret:
      secretName: "my-certificates-ca-tls"
      items:
        - key: "ca.crt"
          path: "ca-certificates.crt"
extraVolumeMounts:
  - name: "trusted-cert-secret-volume"
    mountPath: "/etc/ssl/certs/ca-certificates.crt"
    subPath: "ca-certificates.crt"
``` 