### PR TITLE
fix(openproject): Replace timestamp in job by revision

### DIFF
--- a/.changeset/mighty-tigers-knock.md
+++ b/.changeset/mighty-tigers-knock.md
@@ -1,0 +1,7 @@
+---
+"@openproject/helm-charts": major
+---
+
+- Breaking change: Use revision, not current date in seeder job name
+- Allow keeping seeder jobs around after their execution
+- Configurable TTL for seeder job

--- a/charts/openproject/templates/seeder-job.yaml
+++ b/charts/openproject/templates/seeder-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "common.names.fullname" . }}-seeder-{{ now | date "20060102150405" }}
+  name: {{ include "common.names.fullname" . }}-seeder-{{ .Release.Revision }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
   {{- with .Values.seederJob.annotations }}
@@ -9,7 +9,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  ttlSecondsAfterFinished: 6000
+  {{- if .Values.cleanup.deletePodsOnSuccess }}
+  ttlSecondsAfterFinished: {{ .Values.cleanup.deletePodsOnSuccessTimeout }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -27,6 +27,17 @@ global:
 #
 affinity: {}
 
+## Cleanup settings.
+#
+cleanup:
+  # Keep Pods/Job logs after successful run.
+  #
+  deletePodsOnSuccess: true
+
+  # Keep Pods/Job logs for the following time.
+  #
+  deletePodsOnSuccessTimeout: 6000
+
 ## Define additional environment variables.
 ##
 ## You can get a list of all environment variables when executing:

--- a/spec/charts/openproject/seeder_cleanup_spec.rb
+++ b/spec/charts/openproject/seeder_cleanup_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe 'seeder cleanup configuration' do
+  let(:template) { HelmTemplate.new(default_values) }
+
+  let(:definitions) {
+    [
+      /optest-openproject-seeder/
+    ]
+  }
+
+  context 'when setting other TTL' do
+    let(:default_values) do
+      HelmTemplate.with_defaults(<<~YAML
+        cleanup:
+          deletePodsOnSuccess: true
+          deletePodsOnSuccessTimeout: 1234
+      YAML
+      )
+    end
+
+    it 'Populates annotations for all deployments', :aggregate_failures do
+      definitions.each do |name|
+        expect(template.spec(name)['ttlSecondsAfterFinished']).to eq(1234)
+      end
+    end
+  end
+
+  context 'when disabling deletePodsOnSuccess' do
+    let(:default_values) do
+      HelmTemplate.with_defaults(<<~YAML
+        cleanup:
+          deletePodsOnSuccess: false
+          deletePodsOnSuccessTimeout: 1234
+      YAML
+      )
+    end
+
+    it 'Populates annotations for all deployments', :aggregate_failures do
+      definitions.each do |name|
+        expect(template.spec(name)['ttlSecondsAfterFinished']).to be_nil
+      end
+    end
+  end
+
+  context 'when cleaning up' do
+    let(:default_values) do
+      {}
+    end
+
+    it 'Populates defaults for all deployments', :aggregate_failures do
+      definitions.each do |name|
+        expect(template.spec(name)['ttlSecondsAfterFinished']).to eq(6000)
+      end
+    end
+  end
+end

--- a/spec/helm_template.rb
+++ b/spec/helm_template.rb
@@ -95,8 +95,12 @@ class HelmTemplate
     end
   end
 
+  def spec(item)
+    @mapped.dig(mapped_key(item), 'spec')
+  end
+
   def template_spec(item)
-    @mapped.dig(mapped_key(item), 'spec', 'template', 'spec')
+    spec(item).dig('template', 'spec')
   end
 
   def find_volume(item, volume_name)


### PR DESCRIPTION
During our first steps in GitOps, we discovered that using a timestamp in job name, there is always display pending change (caused by the now ) - The revision should be a suitable replacement for this.

Additionally, there is now an option to control, weather a the seeder job is removed or not, again, needed for GitOps.