### PR TITLE
Allow specifying storageClassName for tmp volumes

### DIFF
--- a/charts/openproject/templates/_helpers.tpl
+++ b/charts/openproject/templates/_helpers.tpl
@@ -92,6 +92,9 @@ securityContext:
   ephemeral:
     volumeClaimTemplate:
       spec:
+        {{- if .Values.tmpVolumesStorageClassName }}
+        storageClassName: {{ .Values.tmpVolumesStorageClassName }}
+        {{- end }}
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
@@ -102,6 +105,9 @@ securityContext:
   ephemeral:
     volumeClaimTemplate:
       spec:
+        {{- if .Values.tmpVolumesStorageClassName }}
+        storageClassName: {{ .Values.tmpVolumesStorageClassName }}
+        {{- end }}
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:

--- a/charts/openproject/templates/_helpers.tpl
+++ b/charts/openproject/templates/_helpers.tpl
@@ -92,8 +92,8 @@ securityContext:
   ephemeral:
     volumeClaimTemplate:
       spec:
-        {{- if .Values.tmpVolumesStorageClassName }}
-        storageClassName: {{ .Values.tmpVolumesStorageClassName }}
+        {{- if .Values.openproject.tmpVolumesStorageClassName }}
+        storageClassName: {{ .Values.openproject.tmpVolumesStorageClassName }}
         {{- end }}
         accessModes: ["ReadWriteOnce"]
         resources:
@@ -105,8 +105,8 @@ securityContext:
   ephemeral:
     volumeClaimTemplate:
       spec:
-        {{- if .Values.tmpVolumesStorageClassName }}
-        storageClassName: {{ .Values.tmpVolumesStorageClassName }}
+        {{- if .Values.openproject.tmpVolumesStorageClassName }}
+        storageClassName: {{ .Values.openproject.tmpVolumesStorageClassName }}
         {{- end }}
         accessModes: ["ReadWriteOnce"]
         resources:

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -345,6 +345,9 @@ openproject:
   #
   useTmpVolumes:
 
+  ## customize the tmp storage mount storage class
+  tmpVolumesStorageClassName:
+
   ## customize the tmp storage mount sizes
   tmpVolumesStorage: "5Gi"
 


### PR DESCRIPTION
Whenever the helm release gets updated, new tmp volumes get created. I'd like to be able to specify a different `storageClassName` for those, for example to have a `Delete` reclaim policy.