### PR TITLE
add resource limit for init-container

### DIFF
--- a/.changeset/mighty-rocks-relax.md
+++ b/.changeset/mighty-rocks-relax.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": patch
+---
+
+add resource limit for init-container

--- a/charts/openproject/templates/web-deployment.yaml
+++ b/charts/openproject/templates/web-deployment.yaml
@@ -65,6 +65,8 @@ spec:
           command:
             - bash
             - /app/docker/prod/wait-for-db
+          resources:
+            {{- toYaml .Values.initdb.resources | nindent 12 }}
       containers:
         - name: "openproject"
           {{- include "openproject.containerSecurityContext" . | indent 10 }}


### PR DESCRIPTION
Use the initdb.resources for wait-for-db too. This is necessary as we have LimitRange configured for a whole namespace. The init container fails with the default resource limit.