### PR TITLE
Bump OpenProject to 14.6.0

### DIFF
--- a/.changeset/old-tables-applaud.md
+++ b/.changeset/old-tables-applaud.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": minor
+---
+
+Bump OpenProject version to 14.6.0

--- a/charts/openproject/Chart.yaml
+++ b/charts/openproject/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for running OpenProject via Kubernetes
 home: https://www.openproject.org/
 icon: https://charts.openproject.org/logo.svg
 type: application
-appVersion: '14'
+appVersion: '14.6.0'
 version: 8.0.0
 maintainers:
 - name: OpenProject

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -201,7 +201,7 @@ image:
   ## For the helm chart, use the `-slim` variants as the all-in-one container is not compatible
   ## with some of the options (non-root execution, password splitting, etc.) and is inefficient for using in helm
   ## due to embedded a number of services.
-  tag: "14-slim"
+  tag: "14.6.0-slim"
 
   ## Define image sha256 - mutual exclusive with image tag.
   ## The sha256 has a higher precedence than


### PR DESCRIPTION
We have decided to start pinning the default OpenProject version so upgrading helm versions become easier. If a new version of OpenProject is released, we will bump the helm chart version.