### PR TITLE
Allow setting the web rollout strategy

### DIFF
--- a/.changeset/afraid-yaks-double.md
+++ b/.changeset/afraid-yaks-double.md
@@ -1,0 +1,17 @@
+---
+"@openproject/helm-charts": minor
+---
+
+Allow setting options for the deployment strategy:
+
+You can now provide custom options to the strategy, for example:
+
+**values.yaml**: 
+
+```yaml
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 30%
+    maxUnavailable: 30%
+```

--- a/charts/openproject/templates/web-deployment.yaml
+++ b/charts/openproject/templates/web-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
-    type: {{ .Values.strategy.type }}
+    {{ .Values.strategy | toYaml | nindent 4 }}
   selector:
     matchLabels:
       {{- include "common.labels.matchLabels" . | nindent 6 }}

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -261,6 +261,10 @@ strategy:
   ## Should your cluster support WriteMany volumes, you can change this
   ## to `RollingUpdate`.
   type: "Recreate"
+  # type: RollingUpdate
+  #   rollingUpdate:
+  #     maxSurge: 30%
+  #     maxUnavailable: 30%
 
 # Define the workers to run, their queues, replicas, strategy, and resources
 workers:

--- a/spec/charts/openproject/web_strategy_spec.rb
+++ b/spec/charts/openproject/web_strategy_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe 'setting strategy for web deployment' do
+  let(:template) { HelmTemplate.new(default_values) }
+
+  context 'when setting custom strategy' do
+    let(:default_values) do
+      HelmTemplate.with_defaults(<<~YAML
+        strategy:
+          type: RollingUpdate
+          rollingUpdate:
+            maxSurge: 30%
+            maxUnavailable: 30%
+      YAML
+      )
+    end
+
+    it 'sets that strategy ', :aggregate_failures do
+      strategy = template.dig('Deployment/optest-openproject-web', 'spec', 'strategy')
+      expect(strategy["type"]).to eq "RollingUpdate"
+      expect(strategy["rollingUpdate"]).to include("maxSurge" => "30%", "maxUnavailable" => "30%")
+    end
+  end
+
+  context 'when setting no strategy' do
+    let(:default_values) do
+      {}
+    end
+
+    it 'Creates the default worker', :aggregate_failures do
+      strategy = template.dig('Deployment/optest-openproject-web', 'spec', 'strategy')
+      expect(strategy["type"]).to eq "Recreate"
+      expect(strategy["rollingUpdate"]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
If you use a RollingUpdate strategy, you can now set options like MaxSurge