### PR TITLE
Allow unsetting the host name env OPENPROJECT_HOST__NAME 

### DIFF
--- a/.changeset/clean-apes-teach.md
+++ b/.changeset/clean-apes-teach.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": minor
+---
+
+Allow unsetting the host name env

--- a/charts/openproject/templates/secret_core.yaml
+++ b/charts/openproject/templates/secret_core.yaml
@@ -23,7 +23,7 @@ stringData:
   OPENPROJECT_SEED_LOCALE: {{ .Values.openproject.seed_locale | quote }}
   {{- if .Values.ingress.enabled }}
   OPENPROJECT_HOST__NAME: {{ .Values.openproject.host | default .Values.ingress.host | quote }}
-  {{- else if .Values.openproject.host }}
+  {{- else if .Values.openproject.host -}}
   OPENPROJECT_HOST__NAME: {{ .Values.openproject.host | quote }}
   {{- end }}
   OPENPROJECT_HSTS: {{ .Values.openproject.hsts | quote }}

--- a/charts/openproject/templates/secret_core.yaml
+++ b/charts/openproject/templates/secret_core.yaml
@@ -23,7 +23,7 @@ stringData:
   OPENPROJECT_SEED_LOCALE: {{ .Values.openproject.seed_locale | quote }}
   {{- if .Values.ingress.enabled }}
   OPENPROJECT_HOST__NAME: {{ .Values.openproject.host | default .Values.ingress.host | quote }}
-  {{- else }}
+  {{- else if .Values.openproject.host }}
   OPENPROJECT_HOST__NAME: {{ .Values.openproject.host | quote }}
   {{- end }}
   OPENPROJECT_HSTS: {{ .Values.openproject.hsts | quote }}

--- a/spec/charts/openproject/host_name_spec.rb
+++ b/spec/charts/openproject/host_name_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe 'host name configuration' do
+  let(:template) { HelmTemplate.new(default_values) }
+
+  subject { template.dig('Secret/optest-openproject-core', 'stringData') }
+
+  context 'when setting host' do
+    let(:default_values) do
+      HelmTemplate.with_defaults(<<~YAML
+        openproject:
+          host: bla.example.com
+      YAML
+      )
+    end
+
+    it 'adds a respective ENV', :aggregate_failures do
+      expect(subject)
+        .to include("OPENPROJECT_HOST__NAME" => "bla.example.com")
+    end
+  end
+
+  context 'when setting no host name but leaving ingress enabled' do
+    let(:default_values) do
+      HelmTemplate.with_defaults({})
+    end
+
+    it 'the host name is the default', :aggregate_failures do
+      expect(subject)
+        .to include("OPENPROJECT_HOST__NAME" => "openproject.example.com")
+    end
+  end
+
+  context 'when setting no host name and disabling ingress' do
+    let(:default_values) do
+      HelmTemplate.with_defaults(<<~YAML
+        ingress:
+          enabled: false
+      YAML
+      )
+    end
+
+    it 'the host is not output', :aggregate_failures do
+      expect(subject.keys)
+        .not_to include("OPENPROJECT_HOST__NAME")
+    end
+  end
+end


### PR DESCRIPTION
If there is no host or it's empty, we do not want to output it.