### PR TITLE
also provide writable tmp volumes for db init check

### DIFF
--- a/.changeset/three-laws-sniff.md
+++ b/.changeset/three-laws-sniff.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": minor
+---
+
+also provide writable tmp volumes for db init check

--- a/charts/openproject/templates/seeder-job.yaml
+++ b/charts/openproject/templates/seeder-job.yaml
@@ -55,6 +55,8 @@ spec:
             {{- include "openproject.env" . | nindent 12 }}
           resources:
             {{- toYaml .Values.dbInit.resources | nindent 12 }}
+          volumeMounts:
+            {{- include "openproject.tmpVolumeMounts" . | indent 12 }}
           {{- include "openproject.containerSecurityContext" . | indent 10 }}
       containers:
         - name: seeder

--- a/charts/openproject/templates/web-deployment.yaml
+++ b/charts/openproject/templates/web-deployment.yaml
@@ -67,6 +67,8 @@ spec:
             - /app/docker/prod/wait-for-db
           resources:
             {{- toYaml .Values.appInit.resources | nindent 12 }}
+          volumeMounts:
+            {{- include "openproject.tmpVolumeMounts" . | indent 12 }}
       containers:
         - name: "openproject"
           {{- include "openproject.containerSecurityContext" . | indent 10 }}

--- a/charts/openproject/templates/worker-deployment.yaml
+++ b/charts/openproject/templates/worker-deployment.yaml
@@ -69,6 +69,8 @@ spec:
             - /app/docker/prod/wait-for-db
           resources:
             {{- toYaml .Values.appInit.resources | nindent 12 }}
+          volumeMounts:
+            {{- include "openproject.tmpVolumeMounts" . | indent 12 }}
       containers:
         - name: "openproject"
           {{- include "openproject.containerSecurityContext" . | indent 10 }}


### PR DESCRIPTION
so used rails runner is guaranteed to work

specifically when appsignal is configured, it will try to write a log file and fail due to the read-only file system (if configured which it is by default)

This ought to fix the issue we are observing when appsignal is configured:

```
wait-for-db appsignal: Unable to log to '/app/log' or the '/tmp' fallback. Please check the permissions for the application's (log) directory.
```

It turns out, though, that this is not the main issue. The main issue is not appsignal at all but mini_magick since the latest update:

```
wait-for-db /usr/local/lib/ruby/3.4.0/tmpdir.rb:44:in 'Dir.tmpdir': could not find a temporary directory (ArgumentError)                                                                    
wait-for-db                                                                                                                                                               
wait-for-db     end or raise ArgumentError, "could not find a temporary directory"
wait-for-db                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                          
wait-for-db     from /app/vendor/bundle/ruby/3.4.0/gems/mini_magick-5.1.2/lib/mini_magick/configuration.rb:71:in 'MiniMagick::Configuration.extended'
```

Either way, adding the tmp volumes fixes both issues.