### PR TITLE
Add option to provide admin user password as an external secret

### DIFF
--- a/charts/openproject/templates/secret_core.yaml
+++ b/charts/openproject/templates/secret_core.yaml
@@ -73,7 +73,8 @@ stringData:
   {{- if .Values.postgresql.options.sslMinProtocolVersion }}
   OPENPROJECT_DB_SSL_MIN_PROTOCOL_VERSION: {{ .Values.postgresql.options.sslMinProtocolVersion | toString }}
   {{- end }}
-  OPENPROJECT_SEED_ADMIN_USER_PASSWORD: {{ .Values.openproject.admin_user.password | quote }}
+  {{ $secret := (lookup "v1" "Secret" .Release.Namespace (default "_" .Values.openproject.admin_user.secret)) | default (dict "data" dict) -}}
+  OPENPROJECT_SEED_ADMIN_USER_PASSWORD: {{ default .Values.openproject.admin_user.password (get $secret.data .Values.openproject.admin_user.secretKeys.password | b64dec) | quote }}
   OPENPROJECT_SEED_ADMIN_USER_PASSWORD_RESET: {{ .Values.openproject.admin_user.password_reset | quote }}
   OPENPROJECT_SEED_ADMIN_USER_NAME: {{ .Values.openproject.admin_user.name | quote }}
   OPENPROJECT_SEED_ADMIN_USER_MAIL: {{ .Values.openproject.admin_user.mail | quote }}

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -345,6 +345,12 @@ openproject:
     password_reset: "true"
     name: "OpenProject Admin"
     mail: "admin@example.net"
+
+    secret: ""
+
+    ## In case your secret does not use the default key in the secret, you can adjust it here
+    secretKeys:
+      password: ""
     # Uncomment if you want to lock the user after creation
     # Relevant for automated deployments that seed LDAP or SSO
     # locked: true


### PR DESCRIPTION
Allows to provide the admin user password with an existing secret as well as to define the key storing the password within the secret.