### PR TITLE
fix: Provide writable tmp volumes for db init check in cronjob

### DIFF
--- a/.changeset/clean-turtles-march.md
+++ b/.changeset/clean-turtles-march.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": patch
+---
+
+fix: Provide writable tmp volumes for db init check in cronjob

--- a/charts/openproject/templates/cron-deployment.yaml
+++ b/charts/openproject/templates/cron-deployment.yaml
@@ -70,6 +70,8 @@ spec:
             - /app/docker/prod/wait-for-db
           resources:
             {{- toYaml .Values.appInit.resources | nindent 12 }}
+          volumeMounts:
+            {{- include "openproject.tmpVolumeMounts" . | indent 12 }}
       containers:
         - name: "cron"
           {{- include "openproject.containerSecurityContext" . | indent 10 }}


### PR DESCRIPTION
Analogous to commit 846b5a7 provide writable tmp volumes to the init container `wait-for-db`.