### PR TITLE
fix: override namespace with templating

### DIFF
--- a/charts/openproject/templates/cron-deployment.yaml
+++ b/charts/openproject/templates/cron-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "common.names.fullname" . }}-cron
+  namespace: {{ include "common.names.namespace" . }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
     openproject/process: cron

--- a/charts/openproject/templates/ingress.yaml
+++ b/charts/openproject/templates/ingress.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/openproject/templates/persistentvolumeclaim.yaml
+++ b/charts/openproject/templates/persistentvolumeclaim.yaml
@@ -5,6 +5,7 @@ apiVersion: "v1"
 kind: "PersistentVolumeClaim"
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
   {{- with .Values.persistence.annotations }}

--- a/charts/openproject/templates/secret_core.yaml
+++ b/charts/openproject/templates/secret_core.yaml
@@ -3,6 +3,7 @@ apiVersion: "v1"
 kind: "Secret"
 metadata:
   name: "{{ include "common.names.fullname" . }}-core"
+  namespace: {{ include "common.names.namespace" . }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 data: # reset data to make sure only keys defined below remain
@@ -73,7 +74,7 @@ stringData:
   {{- if .Values.postgresql.options.sslMinProtocolVersion }}
   OPENPROJECT_DB_SSL_MIN_PROTOCOL_VERSION: {{ .Values.postgresql.options.sslMinProtocolVersion | toString }}
   {{- end }}
-  {{ $secret := (lookup "v1" "Secret" .Release.Namespace (default "_" .Values.openproject.admin_user.secret)) | default (dict "data" dict) -}}
+  {{ $secret := (lookup "v1" "Secret" (include "common.names.namespace" .) (default "_" .Values.openproject.admin_user.secret)) | default (dict "data" dict) -}}
   OPENPROJECT_SEED_ADMIN_USER_PASSWORD: {{ default .Values.openproject.admin_user.password (get $secret.data .Values.openproject.admin_user.secretKeys.password | b64dec) | quote }}
   OPENPROJECT_SEED_ADMIN_USER_PASSWORD_RESET: {{ .Values.openproject.admin_user.password_reset | quote }}
   OPENPROJECT_SEED_ADMIN_USER_NAME: {{ .Values.openproject.admin_user.name | quote }}

--- a/charts/openproject/templates/secret_cron_environment.yaml
+++ b/charts/openproject/templates/secret_cron_environment.yaml
@@ -4,6 +4,7 @@ apiVersion: "v1"
 kind: "Secret"
 metadata:
   name: "{{ include "common.names.fullname" . }}-cron-environment"
+  namespace: {{ include "common.names.namespace" . }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 data: # reset data to make sure only keys defined below remain
@@ -12,7 +13,7 @@ stringData:
   {{- range $key, $value := omit .Values.cron.environment "IMAP_USERNAME" "IMAP_PASSWORD" }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
-  {{ $secret := (lookup "v1" "Secret" .Release.Namespace (default "_" .Values.cron.existingSecret)) | default (dict "data" dict) -}}
+  {{ $secret := (lookup "v1" "Secret" (include "common.names.namespace" .) (default "_" .Values.cron.existingSecret)) | default (dict "data" dict) -}}
   IMAP_USERNAME: {{
     default .Values.cron.environment.IMAP_USERNAME (get $secret.data .Values.cron.secretKeys.imapUsername | b64dec) | quote
   }}

--- a/charts/openproject/templates/secret_environment.yaml
+++ b/charts/openproject/templates/secret_environment.yaml
@@ -4,6 +4,7 @@ apiVersion: "v1"
 kind: "Secret"
 metadata:
   name: "{{ include "common.names.fullname" . }}-environment"
+  namespace: {{ include "common.names.namespace" . }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 data: # reset data to make sure only keys defined below remain

--- a/charts/openproject/templates/secret_memcached.yaml
+++ b/charts/openproject/templates/secret_memcached.yaml
@@ -4,6 +4,7 @@ apiVersion: "v1"
 kind: "Secret"
 metadata:
   name: "{{ include "common.names.fullname" . }}-memcached"
+  namespace: {{ include "common.names.namespace" . }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 data: # reset data to make sure only keys defined below remain

--- a/charts/openproject/templates/secret_oidc.yaml
+++ b/charts/openproject/templates/secret_oidc.yaml
@@ -4,6 +4,7 @@ apiVersion: "v1"
 kind: "Secret"
 metadata:
   name: "{{ include "common.names.fullname" . }}-oidc"
+  namespace: {{ include "common.names.namespace" . }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 data: # reset data to make sure only keys defined below remain
@@ -13,7 +14,7 @@ stringData:
   {{ $oidc_prefix }}_DISPLAY__NAME: {{ .Values.openproject.oidc.displayName | quote }}
   {{ $oidc_prefix }}_HOST: {{ .Values.openproject.oidc.host | quote }}
   {{/* Fall back to '_' as secret name if the name is not given. This way `lookup` will return null (since secrets with this name will and cannot exist) which it doesn't with an empty string. */}}
-  {{ $secret := (lookup "v1" "Secret" .Release.Namespace (default "_" .Values.openproject.oidc.existingSecret)) | default (dict "data" dict) -}}
+  {{ $secret := (lookup "v1" "Secret" (include "common.names.namespace" .) (default "_" .Values.openproject.oidc.existingSecret)) | default (dict "data" dict) -}}
   {{ $oidc_prefix }}_IDENTIFIER: {{
     default .Values.openproject.oidc.identifier (get $secret.data .Values.openproject.oidc.secretKeys.identifier | b64dec) | quote
   }}

--- a/charts/openproject/templates/secret_s3.yaml
+++ b/charts/openproject/templates/secret_s3.yaml
@@ -4,6 +4,7 @@ apiVersion: "v1"
 kind: "Secret"
 metadata:
   name: "{{ include "common.names.fullname" . }}-s3"
+  namespace: {{ include "common.names.namespace" . }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 data: # reset data to make sure only keys defined below remain
@@ -11,7 +12,7 @@ stringData:
   OPENPROJECT_ATTACHMENTS__STORAGE: fog
   OPENPROJECT_FOG_CREDENTIALS_PROVIDER: AWS
   {{/* Fall back to '_' as secret name if the name is not given. This way `lookup` will return null (since secrets with this name will and cannot exist) which it doesn't with an empty string. */}}
-  {{ $secret := (lookup "v1" "Secret" .Release.Namespace (default "_" .Values.s3.auth.existingSecret)) | default (dict "data" dict) -}}
+  {{ $secret := (lookup "v1" "Secret" (include "common.names.namespace" .) (default "_" .Values.s3.auth.existingSecret)) | default (dict "data" dict) -}}
   OPENPROJECT_FOG_CREDENTIALS_AWS__ACCESS__KEY__ID: {{
     default .Values.s3.auth.accessKeyId (get $secret.data .Values.s3.auth.secretKeys.accessKeyId | b64dec) | quote
   }}

--- a/charts/openproject/templates/seeder-job.yaml
+++ b/charts/openproject/templates/seeder-job.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "common.names.fullname" . }}-seeder-{{ .Release.Revision }}
+  namespace: {{ include "common.names.namespace" . }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
   {{- with .Values.seederJob.annotations }}

--- a/charts/openproject/templates/service.yaml
+++ b/charts/openproject/templates/service.yaml
@@ -4,6 +4,7 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 spec:

--- a/charts/openproject/templates/serviceaccount.yaml
+++ b/charts/openproject/templates/serviceaccount.yaml
@@ -4,6 +4,7 @@ apiVersion: "v1"
 kind: "ServiceAccount"
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/openproject/templates/tests/test-connection.yaml
+++ b/charts/openproject/templates/tests/test-connection.yaml
@@ -3,6 +3,7 @@ apiVersion: "v1"
 kind: "Pod"
 metadata:
   name: "{{ include "common.names.fullname" . }}-test-connection"
+  namespace: {{ include "common.names.namespace" . }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
   annotations:

--- a/charts/openproject/templates/web-deployment.yaml
+++ b/charts/openproject/templates/web-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "common.names.fullname" . }}-web
+  namespace: {{ include "common.names.namespace" . }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
     openproject/process: web

--- a/charts/openproject/templates/worker-deployment.yaml
+++ b/charts/openproject/templates/worker-deployment.yaml
@@ -5,6 +5,7 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "common.names.fullname" . }}-worker-{{ $workerName }}
+  namespace: {{ include "common.names.namespace" $ }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
     openproject/process: worker-{{ $workerName }}


### PR DESCRIPTION
Setting the namespace of the OpenProject Helm chart with `helm template` is not possible since the OP namespaced resources have no templated `namespace` properties. If you run:

```console
$ cd charts/openproject
$ helm template myrelease -n myns . 2>/dev/null | grep namespace: | wc -l
8
```

you will notice that only the PostgreSQL and Memcached subchart resources are getting the specified namespace.

Since OP already depends on the Bitnami `common` library chart, we use its `common.names.namespace` template for namespace overriding. Now the OP resources are also getting the `myns` namespace:

```console
$ helm template myrelease -n myns . 2>/dev/null | grep namespace: | wc -l
20
```