### PR TITLE
Add maxThreads parameter to worker deployments

### DIFF
--- a/.changeset/tricky-tables-reflect.md
+++ b/.changeset/tricky-tables-reflect.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": minor
+---
+
+Add maxThreads parameter to worker deployments.

--- a/charts/openproject/templates/worker-deployment.yaml
+++ b/charts/openproject/templates/worker-deployment.yaml
@@ -85,6 +85,10 @@ spec:
             {{- include "openproject.env" . | nindent 12 }}
             - name: "OPENPROJECT_GOOD_JOB_QUEUES"
               value: "{{ $workerValues.queues }}"
+            {{- if not (empty $workerValues.maxThreads) }}
+            - name: "OPENPROJECT_GOOD_JOB_MAX_THREADS"
+              value: "{{ $workerValues.maxThreads }}"
+            {{- end }}
           volumeMounts:
             {{- include "openproject.tmpVolumeMounts" . | indent 12 }}
             {{- if .Values.persistence.enabled }}

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -287,11 +287,14 @@ cron:
     imapUsername: imapUsername
     imapPassword: imapPassword
 
-# Define the workers to run, their queues, replicas, strategy, and resources
+# Define the workers to run, their queues, max threads, replicas, strategy, and resources
 workers:
   default:
     queues: ""
-    replicas: 1
+    # Set a maxThreads value to override the default of 20
+    # It needs to be an integer greater than 0.
+    maxThreads:
+    replicaCount: 1
     strategy:
       type: "Recreate"
     resources:


### PR DESCRIPTION
Adding it will override the default of 20 by setting the env variable `OPENPROJECT_GOOD_JOB_MAX_THREADS`.

It needs to be an integer greater than 0.