### PR TITLE
no longer use helper that was removed in most recent version of bitnami common

### DIFF
--- a/charts/openproject/templates/ingress.yaml
+++ b/charts/openproject/templates/ingress.yaml
@@ -25,9 +25,7 @@ spec:
       http:
         paths:
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
 ...
 {{- end }}


### PR DESCRIPTION
the helper merely checked if the k8s version was >= 1.18 which ought to be the case everywhere by now

see https://github.com/bitnami/charts/commit/3826a9e1488c12545f11cf8cb1a11d23daf90602#diff-3c4828d77ded461f2d0fb882abf7608ce20c1ff0d5a22a1e7752c413eabf7450L42-R38