### PR TITLE
Containers no longer override image entrypoint

### DIFF
--- a/.changeset/tiny-hornets-hammer.md
+++ b/.changeset/tiny-hornets-hammer.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": patch
+---
+
+No longer override image entrypoint

--- a/charts/openproject/templates/cron-deployment.yaml
+++ b/charts/openproject/templates/cron-deployment.yaml
@@ -66,6 +66,7 @@ spec:
           env:
             {{- include "openproject.env" . | nindent 12 }}
           args:
+            - bash
             - /app/docker/prod/wait-for-db
           resources:
             {{- toYaml .Values.appInit.resources | nindent 12 }}
@@ -81,6 +82,7 @@ spec:
             - secretRef:
                 name: {{ include "common.names.fullname" . }}-cron-environment
           args:
+            - bash
             - /app/docker/prod/cron
           env:
             {{- include "openproject.env" . | nindent 12 }}

--- a/charts/openproject/templates/cron-deployment.yaml
+++ b/charts/openproject/templates/cron-deployment.yaml
@@ -65,8 +65,7 @@ spec:
                 name: {{ include "common.names.fullname" . }}-cron-environment
           env:
             {{- include "openproject.env" . | nindent 12 }}
-          command:
-            - bash
+          args:
             - /app/docker/prod/wait-for-db
           resources:
             {{- toYaml .Values.appInit.resources | nindent 12 }}
@@ -81,8 +80,7 @@ spec:
             {{- include "openproject.envFrom" . | nindent 12 }}
             - secretRef:
                 name: {{ include "common.names.fullname" . }}-cron-environment
-          command:
-            - bash
+          args:
             - /app/docker/prod/cron
           env:
             {{- include "openproject.env" . | nindent 12 }}

--- a/charts/openproject/templates/seeder-job.yaml
+++ b/charts/openproject/templates/seeder-job.yaml
@@ -63,7 +63,6 @@ spec:
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}{{ if .Values.image.sha256 }}@sha256:{{ .Values.image.sha256 }}{{ else }}:{{ .Values.image.tag }}{{ end }}"
           imagePullPolicy: {{ .Values.image.imagePullPolicy }}
           args:
-            - bash
             - /app/docker/prod/seeder
           envFrom:
             {{- include "openproject.envFrom" . | nindent 12 }}

--- a/charts/openproject/templates/seeder-job.yaml
+++ b/charts/openproject/templates/seeder-job.yaml
@@ -63,6 +63,7 @@ spec:
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}{{ if .Values.image.sha256 }}@sha256:{{ .Values.image.sha256 }}{{ else }}:{{ .Values.image.tag }}{{ end }}"
           imagePullPolicy: {{ .Values.image.imagePullPolicy }}
           args:
+            - bash
             - /app/docker/prod/seeder
           envFrom:
             {{- include "openproject.envFrom" . | nindent 12 }}

--- a/charts/openproject/templates/web-deployment.yaml
+++ b/charts/openproject/templates/web-deployment.yaml
@@ -62,8 +62,7 @@ spec:
             {{- include "openproject.envFrom" . | nindent 12 }}
           env:
             {{- include "openproject.env" . | nindent 12 }}
-          command:
-            - bash
+          args:
             - /app/docker/prod/wait-for-db
           resources:
             {{- toYaml .Values.appInit.resources | nindent 12 }}
@@ -78,8 +77,7 @@ spec:
             {{- include "openproject.envFrom" . | nindent 12 }}
           env:
             {{- include "openproject.env" . | nindent 12 }}
-          command:
-            - bash
+          args:
             - /app/docker/prod/web
           volumeMounts:
             {{- include "openproject.tmpVolumeMounts" . | indent 12 }}

--- a/charts/openproject/templates/worker-deployment.yaml
+++ b/charts/openproject/templates/worker-deployment.yaml
@@ -65,6 +65,7 @@ spec:
           env:
             {{- include "openproject.env" . | nindent 12 }}
           args:
+            - bash
             - /app/docker/prod/wait-for-db
           resources:
             {{- toYaml .Values.appInit.resources | nindent 12 }}
@@ -78,6 +79,7 @@ spec:
           envFrom:
             {{- include "openproject.envFrom" . | nindent 12 }}
           args:
+            - bash
             - /app/docker/prod/worker
           env:
             {{- include "openproject.env" . | nindent 12 }}

--- a/charts/openproject/templates/worker-deployment.yaml
+++ b/charts/openproject/templates/worker-deployment.yaml
@@ -64,8 +64,7 @@ spec:
             {{- include "openproject.envFrom" . | nindent 12 }}
           env:
             {{- include "openproject.env" . | nindent 12 }}
-          command:
-            - bash
+          args:
             - /app/docker/prod/wait-for-db
           resources:
             {{- toYaml .Values.appInit.resources | nindent 12 }}
@@ -78,8 +77,7 @@ spec:
           imagePullPolicy: {{ .Values.image.imagePullPolicy }}
           envFrom:
             {{- include "openproject.envFrom" . | nindent 12 }}
-          command:
-            - bash
+          args:
             - /app/docker/prod/worker
           env:
             {{- include "openproject.env" . | nindent 12 }}


### PR DESCRIPTION
Kubernetes `command` is for overriding the image entrypoint. `args` is what should be used instead. Otherwise all the fixes made in the image entrypoints (e.g. `PGBIN`) will be lost.

The seeder was correct.