### PR TITLE
Fix S3 existingSecret configuration ignoring configured secretKeys

### DIFF
--- a/charts/openproject/templates/_helpers.tpl
+++ b/charts/openproject/templates/_helpers.tpl
@@ -177,10 +177,6 @@ securityContext:
 - secretRef:
     name: {{ include "common.names.fullname" . }}-s3
 {{- end }}
-{{- if .Values.s3.auth.existingSecret }}
-- secretRef:
-    name: {{ .Values.s3.auth.existingSecret }}
-{{- end }}
 {{- if eq .Values.openproject.cache.store "memcache" }}
 - secretRef:
     name: {{ include "common.names.fullname" . }}-memcached
@@ -223,6 +219,18 @@ securityContext:
     secretKeyRef:
       name: {{ include "common.names.dependency.fullname" (dict "chartName" "postgresql" "chartValues" .Values.postgresql "context" $) }}
       key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey }}
+{{- end }}
+{{- if .Values.s3.auth.existingSecret}}
+- name: OPENPROJECT_FOG_CREDENTIALS_AWS__ACCESS__KEY__ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.s3.auth.existingSecret }}
+      key: {{ .Values.s3.auth.secretKeys.accessKeyId }}
+- name: OPENPROJECT_FOG_CREDENTIALS_AWS__SECRET__ACCESS__KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.s3.auth.existingSecret }}
+      key: {{ .Values.s3.auth.secretKeys.secretAccessKey }}
 {{- end }}
 {{- if .Values.openproject.realtime_collaboration.enabled }}
 # External backend: we are using an external hocuspocus backend with an existing secret containing the password

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -735,12 +735,11 @@ s3:
     ## use an existing secret containing the S3 compatible access credentials.
     ## Specify the name of this existing secret here.
 
-    # if using an existing secret, use the following keys for your access key and secret.
-    # OPENPROJECT_FOG_CREDENTIALS_AWS__ACCESS__KEY__ID
-    # OPENPROJECT_FOG_CREDENTIALS_AWS__SECRET__ACCESS__KEY
-
     # note there are double underscores on these keys
     existingSecret:
+    secretKeys:
+      accessKeyId: OPENPROJECT_FOG_CREDENTIALS_AWS__ACCESS__KEY__ID
+      secretAccessKey: OPENPROJECT_FOG_CREDENTIALS_AWS__SECRET__ACCESS__KEY
 
   region:
   bucketName:


### PR DESCRIPTION
Fixes #223.

`spec/charts/openproject/s3_spec.rb` probably needs to adapted to this change prior to merge.

I'd kindly ask someone else to take care of that as I don't speak ruby.