### PR TITLE
Switch to legacy repos until their public offering is clear

### DIFF
--- a/.changeset/curly-tables-turn.md
+++ b/.changeset/curly-tables-turn.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": minor
+---
+
+Switch to bitnami secure images for development

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ using helm's [chart-releaser](https://github.com/helm/chart-releaser-action) act
 
 Please refer to our [documentation](https://www.openproject.org/docs/installation-and-operations/installation/helm-chart/) for instructions on how to install the OpenProject helm chart.
 
+### Bitnami charts
+
+Due to Bitnami's move to get rid of their free and public helm offering, we will need to find alternatives for the builtin packages (memacached, postgres). For testing purposes, we currently reference their legacy charts. Please note that they are not subject to updates nor security updates.
+
+For production systems, we recommend you use their security offering, or alternatives (such as CNPG). We are interested in using these alternatives in our charts as well, feel free to provide pull requests to help us in that regard.
+
+
+https://github.com/bitnami/charts/issues/35164
+
 ## GitHub package registry
 
 We publish newer versions of this chart to the GitHub package registry: https://github.com/opf/helm-charts/pkgs/container/helm-charts%2Fopenproject

--- a/charts/openproject/Chart.yaml
+++ b/charts/openproject/Chart.yaml
@@ -12,15 +12,15 @@ maintainers:
   url: https://github.com/opf/helm-charts
 dependencies:
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: "^12.1.6"
   condition: postgresql.bundled
 - name: memcached
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   condition: memcached.bundled
   version: "^6.3.2"
 - name: common
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: "^2.2.2"
 annotations:
   artifacthub.io/license: GPL-3.0-only

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -224,6 +224,10 @@ memcached:
   #
   bundled: true
 
+  ## Override image repository to use Bitnami Secure images
+  image:
+    repository: bitnamisecure/memcached
+
   global:
     containerSecurityContext:
       enabled: true
@@ -588,6 +592,16 @@ postgresql:
   ## own database instance.
   #
   bundled: true
+
+  ## Override image repository to use Bitnami Secure images
+  image:
+    repository: bitnamisecure/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamisecure/os-shell
+  metrics:
+    image:
+      repository: bitnamisecure/postgres-exporter
 
   global:
     containerSecurityContext:

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -226,7 +226,8 @@ memcached:
 
   ## Override image repository to use Bitnami Secure images
   image:
-    repository: bitnamisecure/memcached
+    repository: bitnamilegacy/memcached
+    tag: 1.6.24-debian-12-r0
 
   global:
     containerSecurityContext:
@@ -595,13 +596,14 @@ postgresql:
 
   ## Override image repository to use Bitnami Secure images
   image:
-    repository: bitnamisecure/postgresql
+    repository: bitnamilegacy/postgresql
+    tag: 15.4.0-debian-11-r45
   volumePermissions:
     image:
-      repository: bitnamisecure/os-shell
+      repository: bitnamilegacy/os-shell
   metrics:
     image:
-      repository: bitnamisecure/postgres-exporter
+      repository: bitnamilegacy/postgres-exporter
 
   global:
     containerSecurityContext:


### PR DESCRIPTION

Due to Bitnami's move to get rid of their free and public helm offering, we will need to find alternatives for the builtin packages (memacached, postgres). For testing purposes, we currently reference their legacy charts. Please note that they are not subject to updates nor security updates.

For production systems, we recommend you use their security offering, or alternatives (such as CNPG). We are interested in using these alternatives in our charts as well, feel free to provide pull requests to help us in that regard.


https://github.com/bitnami/charts/issues/35164