### PR TITLE
Openshift routes TLS termination edge, TLS ingress deactivate

### DIFF
--- a/charts/openproject/README.md
+++ b/charts/openproject/README.md
@@ -407,3 +407,16 @@ memcached:
   podSecurityContext:
     enabled: false
 ```
+
+If Openshift routes with TLS termination `edge` are to be used, TLS of the ingress must be deactivated.
+
+```
+ingress:
+  host: openproject.example.com
+  annotations:
+    # generate openshift route
+    route.openshift.io/termination: "edge"
+  # openshift router offers TLS on edge
+  tls:
+    enabled: false
+```


### PR DESCRIPTION
[Creating a route through an Ingress object](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/ingress_and_load_balancing/configuring-routes#nw-ingress-creating-a-route-via-an-ingress_route-configuration) with TLS termination edge