### PR TITLE
make cron-deployment resources variable

### DIFF
--- a/charts/openproject/templates/cron-deployment.yaml
+++ b/charts/openproject/templates/cron-deployment.yaml
@@ -103,9 +103,4 @@ spec:
             {{- end }}
             {{- include "openproject.extraVolumeMounts" . | indent 12 }}
           resources:
-            requests:
-              memory: "256Mi"
-              cpu: "250m"
-            limits:
-              memory: "1Gi"
-              cpu: "1"
+            {{- coalesce .Values.cron.resources .Values.resources | toYaml | nindent 12 }}

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -355,6 +355,13 @@ cron:
   secretKeys:
     imapUsername: imapUsername
     imapPassword: imapPassword
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "250m"
+    limits:
+      memory: "1Gi"
+      cpu: "1"
 
 # Define the workers to run, their queues, max threads, replicas, strategy, and resources
 workers:


### PR DESCRIPTION
We have an policy: CPU request above 100m, so I need to configure crons resources.

I moved the original hard coded resources to values.yaml, but with this contradicts with the coalesce. I would prefer to remove the default resources from values.yaml. And stick to .Values.resources as default. Same in Worker #249