### PR TITLE
Allow hocuspocus server to use the new ALLOWED_DOMAINS env variable

### DIFF
--- a/.changeset/bright-swans-wink.md
+++ b/.changeset/bright-swans-wink.md
@@ -1,0 +1,6 @@
+---
+"@openproject/helm-charts": patch
+---
+
+- Remove hocuspocus SECRET environment variable as we will not be using it anymore
+- Allow hocuspocus server to use the new ALLOWED_DOMAINS env variable

--- a/charts/openproject/templates/_helpers.tpl
+++ b/charts/openproject/templates/_helpers.tpl
@@ -193,18 +193,6 @@ securityContext:
       name: {{ include "common.names.dependency.fullname" (dict "chartName" "postgresql" "chartValues" .Values.postgresql "context" $) }}
       key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey }}
 {{- end }}
-{{- if .Values.hocuspocus.enabled }}
-{{- if .Values.hocuspocus.auth.existingSecret }}
-- name: OPENPROJECT_COLLABORATIVE__EDITING__HOCUSPOCUS__SECRET
-  valueFrom:
-    secretKeyRef:
-      name: {{ .Values.hocuspocus.auth.existingSecret }}
-      key: {{ .Values.hocuspocus.auth.secretKey }}
-{{- else }}
-- name: OPENPROJECT_COLLABORATIVE__EDITING__HOCUSPOCUS__SECRET
-  value: {{ .Values.hocuspocus.auth.password }}
-{{- end }}
-{{- end }}
 {{- end }}
 
 {{- define "openproject.envChecksums" }}

--- a/charts/openproject/templates/hocuspocus-deployment.yaml
+++ b/charts/openproject/templates/hocuspocus-deployment.yaml
@@ -47,11 +47,8 @@ spec:
           image: "{{ with .Values.hocuspocus.image }}{{ .registry }}/{{ .repository }}:{{ .tag }}{{ end }}"
           imagePullPolicy: {{ .Values.hocuspocus.image.imagePullPolicy }}
           env:
-            - name: SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.hocuspocus.auth.existingSecret }}
-                  key: {{ .Values.hocuspocus.auth.secretKey }}
+            - name: ALLOWED_DOMAINS
+              value: {{ join "," .Values.hocuspocus.allowedOpenProjectDomains | quote }}
           volumeMounts:
             {{- if .Values.egress.tls.rootCA.fileName }}
             - name: ca-pemstore

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -404,10 +404,6 @@ hocuspocus:
       enabled: true
       secretName: ""
 
-  auth:
-    existingSecret:
-    secretKey: secret
-
   image:
     registry: "docker.io"
     repository: "openproject/hocuspocus"
@@ -418,6 +414,9 @@ hocuspocus:
     type: "Recreate"
 
   podAnnotations:
+
+  allowedOpenProjectDomains:
+    - openproject.example.com
 
   service:
     port: 1234


### PR DESCRIPTION
Hocuspocus server needs a environment variable called ALLOWED_DOMAINS with a comma separated list of domains that it can reach to use the API;

This means something like the following in the hocuspocus instance that serves as the YJS provider for the community OpenProject instance

```
ALLOWED_DOMAINS=community.openproject.com
```

The hocuspocus server will accept values like `openproject.com` for all subdomains.

**important**: this PR also removes the old SECRET environment variable, because it's not necessary anymore on the new implementation.