### PR TITLE
Add `extraEnvVars` option

### DIFF
--- a/.changeset/add-extra-env-vars.md
+++ b/.changeset/add-extra-env-vars.md
@@ -1,0 +1,5 @@
+---
+openproject: patch
+---
+
+Add support for optional `extraEnvVars` in the Helm chart to allow users to inject additional environment variables without modifying templates.

--- a/charts/openproject/templates/_helpers.tpl
+++ b/charts/openproject/templates/_helpers.tpl
@@ -212,6 +212,9 @@ securityContext:
   value: {{ .Values.hocuspocus.auth.password }}
 {{- end }}
 {{- end }}
+{{- if .Values.extraEnvVars }}
+{{- toYaml .Values.extraEnvVars | nindent 0 }}
+{{- end }}
 {{- end }}
 
 {{- define "openproject.envChecksums" }}

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -59,6 +59,9 @@ cleanup:
 #
 environment: {}
 
+# Optionally specify an extra list environment variables.
+extraEnvVars: []
+
 # Optionally specify an extra list of additional volumes.
 extraVolumes: []
 


### PR DESCRIPTION
# Ticket

n/a

# What are you trying to accomplish?

Supporting `extraEnvVars` as a common approach for setting operator owned env vars into the containers.

# What approach did you choose and why?

The `extraEnvVars` section is a common best practise in Helm charts widely used, e.g. 
- openDesk best practises Helm chart
- Bitnami Helm charts 

The specified env vars are included in the helper function `openproject.env` to make them available globally. This does not address a potential need for specific env vars e.g. just in the cron job or just in the web deployment.

# Merge checklist

- [ ] Added/updated tests: No Helm chart tests available, but did manual tests verifying that standard env var definitions (`name` / `value`) and secret references (`name` / `valueFrom`) are working as expected for both use cases: 
```
extraEnvVars:
  - name: "DO_YOU_LIKE_INDENTATION_ON_LISTS"
  - value: "YES"
```
and
```
extraEnvVars:
- name: "DO_YOU_LIKE_INDENTATION_ON_LISTS"
- value: "NO"
```

- [ ] Added/updated documentation in Lookbook (patterns, previews, etc): No, documentation for Helm chart is in the `values.yaml`
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...): No, (end) user facing change
