### PR TITLE
Add templating for repositories, digest, and tag for hocuspocus

### DIFF
--- a/.changeset/mean-hounds-deny.md
+++ b/.changeset/mean-hounds-deny.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": minor
+---
+
+Add digest, policy, and repository for hocuspocus

--- a/charts/openproject/templates/_helpers.tpl
+++ b/charts/openproject/templates/_helpers.tpl
@@ -6,6 +6,30 @@ Returns the OpenProject image to be used including the respective registry and i
 {{- end -}}
 
 {{/*
+Returns the Hocuspocus image to be used including registry, tag and optional digest.
+
+If a sha256 digest is provided, we render `image:tag@sha256:digest` (tag is kept for traceability).
+*/}}
+{{- define "openproject.hocuspocus.image" -}}
+{{- $img := .Values.hocuspocus.image -}}
+{{- $registry := required "hocuspocus.image.registry is required" $img.registry -}}
+{{- $repository := required "hocuspocus.image.repository is required" $img.repository -}}
+{{- $tag := required "hocuspocus.image.tag is required" ($img.tag | toString) -}}
+{{- if $img.sha256 -}}
+{{ $registry }}/{{ $repository }}:{{ $tag }}@sha256:{{ $img.sha256 }}
+{{- else -}}
+{{ $registry }}/{{ $repository }}:{{ $tag }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns the Hocuspocus imagePullPolicy with a safe fallback.
+*/}}
+{{- define "openproject.hocuspocus.imagePullPolicy" -}}
+{{- default .Values.image.imagePullPolicy .Values.hocuspocus.image.imagePullPolicy -}}
+{{- end -}}
+
+{{/*
 Returns the OpenProject image pull secrets, if any are defined
 */}}
 {{- define "openproject.imagePullSecrets" -}}

--- a/charts/openproject/templates/hocuspocus-deployment.yaml
+++ b/charts/openproject/templates/hocuspocus-deployment.yaml
@@ -53,8 +53,8 @@ spec:
       containers:
         - name: "hocuspocus"
           {{- include "openproject.containerSecurityContext" . | indent 10 }}
-          image: "{{ with .Values.hocuspocus.image }}{{ .registry }}/{{ .repository }}:{{ .tag }}{{ end }}"
-          imagePullPolicy: {{ .Values.hocuspocus.image.imagePullPolicy }}
+          image: {{ include "openproject.hocuspocus.image" . }}
+          imagePullPolicy: {{ include "openproject.hocuspocus.imagePullPolicy" . }}
           env:
             {{- if .Values.hocuspocus.auth.existingSecret }}
             - name: SECRET

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -516,6 +516,9 @@ hocuspocus:
     repository: "openproject/hocuspocus"
     imagePullPolicy: "Always"
     tag: "release-338001b2"
+    ## Define image sha256 digest (optional).
+    ## If set, the chart will render `repository:tag@sha256:digest`.
+    # sha256:
 
   strategy:
     type: "Recreate"


### PR DESCRIPTION
- Changed charts/openproject/templates/hocuspocus-deployment.yaml to use a helper (instead of manual string building), matching the pattern used for the openproject image
- Added helper  in charts/openproject/templates/_helpers.tpl for hocuspocus repo/tag/digest
- Add imagePullPolicy for hocuspocus