### PR TITLE
Avoid setting OPENPROJECT_SEED_LOCALE by default

### DIFF
--- a/.changeset/shaky-houses-bake.md
+++ b/.changeset/shaky-houses-bake.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": minor
+---
+
+Avoid setting OPENPROJECT_SEED_LOCALE by default

--- a/charts/openproject/templates/secret_core.yaml
+++ b/charts/openproject/templates/secret_core.yaml
@@ -86,7 +86,9 @@ stringData:
   OPENPROJECT_SEED_ADMIN_USER_LOCKED: "true"
   {{- end }}
   OPENPROJECT_HTTPS: {{ (.Values.develop | ternary "false" .Values.openproject.https) | quote }}
+  {{- if .Values.openproject.seed_locale }}
   OPENPROJECT_SEED_LOCALE: {{ .Values.openproject.seed_locale | quote }}
+  {{- end }}
   {{- $hostname := .Values.openproject.host | default .Values.ingress.host -}}
   {{- if .Values.ingress.enabled }}
   OPENPROJECT_HOST__NAME: {{ $hostname | quote }}

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -564,9 +564,10 @@ openproject:
 
   extraEnvVarsSecret: ""
 
-  ## Define the language to seed the instance in
+  ## Force the language to seed the instance in.
+  # Defaults to English if not set.
   #
-  seed_locale: "en"
+  # seed_locale: "en"
 
   ##
   # Let OpenProject run in a subdirectory,

--- a/spec/charts/openproject/seeder_language_spec.rb
+++ b/spec/charts/openproject/seeder_language_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe 'seeder language configuration' do
+  let(:template) { HelmTemplate.new(default_values) }
+
+  subject { template.dig('Secret/optest-openproject-core', 'stringData') }
+
+  context 'when setting seed_locale' do
+    let(:default_values) do
+      HelmTemplate.with_defaults(<<~YAML
+        openproject:
+          seed_locale: "de"
+      YAML
+      )
+    end
+
+    it 'sets OPENPROJECT_SEED_LOCALE', :aggregate_failures do
+      expect(subject)
+        .to include("OPENPROJECT_SEED_LOCALE" => "de")
+    end
+  end
+
+  context 'when not setting seed_locale' do
+    let(:default_values) { {} }
+
+    it 'does not set OPENPROJECT_SEED_LOCALE', :aggregate_failures do
+      expect(subject)
+        .not_to include("OPENPROJECT_SEED_LOCALE" => anything)
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/62742

# What are you trying to accomplish?

Currently, choosing a language on start.openproject.com has no effect: the instance is seeded with English language. It's because `OPENPROJECT_SEED_LOCALE` is set. When it's set, it takes precedence over `Setting.default_language` and forces the language of the seeded instance.

`OPENPROJECT_SEED_LOCALE` should not be set by default. It should be set only when wanting to choose a specific locale for installation/seeding.

# What approach did you choose and why?

Set `OPENPROJECT_SEED_LOCALE` only if `openproject.seed_locale` is set, and do not set it by default (commented out in `values.yaml`).

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
