### PR TITLE
Add custom labels for cron deployment

### DIFF
--- a/charts/openproject/templates/cron-deployment.yaml
+++ b/charts/openproject/templates/cron-deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-cron
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- range $key, $value := .Values.cron.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
     openproject/process: cron
     app.kubernetes.io/component: cron
   {{- if or .Values.cron.annotations .Values.commonAnnotations }}

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -443,6 +443,10 @@ cron:
   ##
   annotations: {}
 
+  ## Define custom cron deployment labels:
+  ##
+  labels: {}
+
   ## To avoid having sensitive credentials in your values.yaml, the preferred way is to
   ## use an existing secret containing the IMAP credentials.
   ## Specify the name of this existing secret here.


### PR DESCRIPTION
Our Kubernetes-Cluster requires a custom label to be added to pods that use the egress gateway. This patch adds this functionality to the cron-pods in an identical fashion to how it's already implemented for web-workers.
