### PR TITLE
allow the connection test to use a custom/mirrored repo when there's …

### DIFF
--- a/charts/openproject/templates/tests/test-connection.yaml
+++ b/charts/openproject/templates/tests/test-connection.yaml
@@ -12,7 +12,7 @@ spec:
   serviceAccountName: {{ include "common.names.fullname" . }}
   containers:
     - name: "wget"
-      image: "busybox"
+      image: "{{ .Values.connectionTestImage.image }}:{{ .Values.connectionTestImage.tag }}"
       imagePullPolicy: Always
       command: ['wget']
       args:

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -675,6 +675,12 @@ openproject:
   #
   tmpVolumesLabels: {}
 
+## Define the image source for the container started in the test-connection pod.
+#
+connectionTestImage:
+  image: "busybox"
+  tag: "latest"
+
 ## Whether to allocate persistent volume disk for the data directory.
 ## In case of node failure, the node data directory will still persist.
 ##


### PR DESCRIPTION
…no connection to the internet by default

# Ticket
n/a

# What are you trying to accomplish?
The current test-connection.yaml has a hardcoded image "busybox" for the wget test.
If you are on an isolated Kubernetes cluster, you should be able to load the busybox image from your local/mirrored registry.

## Screenshots
n/a

# What approach did you choose and why?
Replace the hard-coded image string with a constructed one from new entries in values.yaml

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
