### PR TITLE
Fix: missing secret key base config

### DIFF
--- a/charts/openproject/README.md
+++ b/charts/openproject/README.md
@@ -69,7 +69,20 @@ By default, the helm chart will target the latest stable major release. You can 
 
 Please make sure to use the `-slim` variant of OpenProject, as the all-in-one container is adding unnecessary services and will not work as expected with default options such as operating as a non-root user.
 
+#### SECRET_KEY_BASE
 
+The `SECRET_KEY_BASE` in rails applications is used to sign or encrypt data such as cookies, sessions or tokens.
+The chart automatically generates a value for this if you don't provide one.
+You can provide one via an existing secret, however.
+
+```
+openproject:
+  secretKeyBase:
+    existingSecret: my-secret-key-base-secret
+    secretKey: secret-key-base
+```
+
+Please refer below to the Secrets section for examples on how to create secrets.
 
 #### HTTPS mode
 

--- a/charts/openproject/templates/_helpers.tpl
+++ b/charts/openproject/templates/_helpers.tpl
@@ -249,6 +249,20 @@ securityContext:
       key: secret
 {{- end }}
 {{- end }}
+{{- if .Values.openproject.secretKeyBase.existingSecret }}
+- name: SECRET_KEY_BASE
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.openproject.secretKeyBase.existingSecret }}
+      key: {{ .Values.openproject.secretKeyBase.secretKey }}
+# if nothing was defined, we use an auto generated secret (see secret_secret_key_base.yaml)
+{{- else }}
+- name: SECRET_KEY_BASE
+  valueFrom:
+    secretKeyRef:
+      name: secret-key-base-auto-generated
+      key: secret-key-base
+{{- end }}
 {{- if .Values.extraEnvVars }}
 {{- toYaml .Values.extraEnvVars | nindent 0 }}
 {{- end }}

--- a/charts/openproject/templates/secret_secret_key_base.yaml
+++ b/charts/openproject/templates/secret_secret_key_base.yaml
@@ -1,0 +1,31 @@
+# Only generate this secret if
+#   a) no existing secret is configured for SECRET_KEY_BASE
+# and if
+#   b) this automatically generated secret does not exist yet.
+{{-
+  if not (
+    or
+      .Values.openproject.secretKeyBase.existingSecret
+      (lookup "v1" "Secret" .Release.Namespace "secret-key-base-auto-generated")
+  )
+}}
+---
+apiVersion: "v1"
+kind: "Secret"
+metadata:
+  name: secret-key-base-auto-generated
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: openproject
+  annotations:
+    # This annotation together with the lookup of the existing secret above ensures that this secret is not
+    # regenerated during each upgrade, but kept the same.
+    "helm.sh/resource-policy": "keep"
+    {{- if .Values.commonAnnotations }}
+      {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+data: # reset data to make sure only keys defined below remain
+stringData:
+  secret-key-base: {{ randAlphaNum 64 }}
+...
+{{- end }}

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -576,6 +576,16 @@ openproject:
   # e.g., /openproject
   railsRelativeUrlRoot:
 
+  ## SECRET_KEY_BASE is required by Rails for cookie signing and other cryptographic operations.
+  ## By default, an auto-generated secret is created on first install and kept across upgrades.
+  ## To use your own secret, provide an existing Kubernetes secret with the key below.
+  secretKeyBase:
+    ## Name of an existing secret containing the SECRET_KEY_BASE value.
+    ## Leave empty to use the auto-generated secret.
+    existingSecret: ""
+    ## Key within the secret that holds the value.
+    secretKey: "secret-key-base"
+
   ## Define admin user details
   # only applicable on first installation
   # c.f. https://www.openproject.org/docs/installation-and-operations/configuration/#initial-admin-user-creation

--- a/spec/charts/openproject/secret_key_base_spec.rb
+++ b/spec/charts/openproject/secret_key_base_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe 'configuring SECRET_KEY_BASE' do
+  let(:template) { HelmTemplate.new(default_values) }
+
+  context 'when no existingSecret is given' do
+    let(:default_values) do
+      HelmTemplate.with_defaults(
+        <<~YAML
+          openproject:
+            secretKeyBase:
+              existingSecret: ""
+        YAML
+      )
+    end
+
+    it 'auto-generates a secret' do
+      secret = template.dig('Secret/secret-key-base-auto-generated')
+
+      expect(secret).not_to be_nil
+      expect(secret.dig('stringData', 'secret-key-base')).not_to be_empty
+    end
+
+    it 'points SECRET_KEY_BASE to the auto-generated secret in the web deployment' do
+      env = template.env_named('Deployment/optest-openproject-web', 'openproject', 'SECRET_KEY_BASE')
+
+      expect(env).not_to be_nil
+      expect(env.dig('valueFrom', 'secretKeyRef', 'name')).to eq 'secret-key-base-auto-generated'
+      expect(env.dig('valueFrom', 'secretKeyRef', 'key')).to eq 'secret-key-base'
+    end
+
+    it 'points SECRET_KEY_BASE to the auto-generated secret in the worker deployment' do
+      env = template.env_named('Deployment/optest-openproject-worker-default', 'openproject', 'SECRET_KEY_BASE')
+
+      expect(env).not_to be_nil
+      expect(env.dig('valueFrom', 'secretKeyRef', 'name')).to eq 'secret-key-base-auto-generated'
+      expect(env.dig('valueFrom', 'secretKeyRef', 'key')).to eq 'secret-key-base'
+    end
+  end
+
+  context 'when an existingSecret is given' do
+    let(:default_values) do
+      HelmTemplate.with_defaults(
+        <<~YAML
+          openproject:
+            secretKeyBase:
+              existingSecret: my-secret-key-base
+              secretKey: my-key
+        YAML
+      )
+    end
+
+    it 'does not auto-generate a secret' do
+      secret = template.dig('Secret/secret-key-base-auto-generated')
+
+      expect(secret).to be_nil
+    end
+
+    it 'points SECRET_KEY_BASE to the existing secret in the web deployment' do
+      env = template.env_named('Deployment/optest-openproject-web', 'openproject', 'SECRET_KEY_BASE')
+
+      expect(env).not_to be_nil
+      expect(env.dig('valueFrom', 'secretKeyRef', 'name')).to eq 'my-secret-key-base'
+      expect(env.dig('valueFrom', 'secretKeyRef', 'key')).to eq 'my-key'
+    end
+
+    it 'points SECRET_KEY_BASE to the existing secret in the worker deployment' do
+      env = template.env_named('Deployment/optest-openproject-worker-default', 'openproject', 'SECRET_KEY_BASE')
+
+      expect(env).not_to be_nil
+      expect(env.dig('valueFrom', 'secretKeyRef', 'name')).to eq 'my-secret-key-base'
+      expect(env.dig('valueFrom', 'secretKeyRef', 'key')).to eq 'my-key'
+    end
+  end
+end

--- a/spec/helm_template.rb
+++ b/spec/helm_template.rb
@@ -18,7 +18,7 @@ class HelmTemplate
     @values = values
     result = Open3.capture3("helm template --debug #{release_name} . #{extra_args} -f -",
                             chdir: File.join(__dir__, '..', 'charts', chart),
-                            stdin_data: YAML.dump(values))
+                            stdin_data: YAML.dump(values).sub(/\A---[ \t]*\n?/, ''))
     @stdout, @stderr, @exit_code = result
     # handle common failures when helm or chart not setup properly
     if @exit_code == 256


### PR DESCRIPTION
WP [#74813](https://community.openproject.org/wp/74813)

While it is possible to configure `SECRET_KEY_BASE` simply as part of the normal `openproject.environment`, its presence is not enforced. So here we extract this into a separate configuration which gets an auto-generated default value to make sure this is always set to a safe (random) value, and not using the OpenProject docker image's static default.