### PR TITLE
Add a global temp directory to use with sticky bit set

### DIFF
--- a/.changeset/tmp-volume-sticky-bit.md
+++ b/.changeset/tmp-volume-sticky-bit.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": minor
+---
+
+Fix Ruby pods crashing on CSI drivers that mount tmp volumes world-writable without the sticky bit. A non-root init container now creates a sticky-bit /tmp/ruby directory and TMPDIR is pointed at it. Can be disabled with openproject.tmpVolumesPermissionFix=false.

--- a/charts/openproject/templates/_helpers.tpl
+++ b/charts/openproject/templates/_helpers.tpl
@@ -99,6 +99,38 @@ securityContext:
 {{- end -}}
 {{- end -}}
 
+{{- define "openproject.fixTmpVolumePermissions" -}}
+{{- if and (eq (include "openproject.useTmpVolumes" .) "true") .Values.openproject.tmpVolumesPermissionFix -}}
+  {{- true -}}
+{{- else -}}
+  {{- false -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Init container that prepares a sticky-bit tmp directory for Ruby's Dir.tmpdir.
+
+Some CSI drivers mount the tmp volume world-writable without the sticky bit,
+which Ruby rejects ("could not find a temporary directory"). We create an
+owned subdirectory and set the sticky bit on it as the non-root app user, so
+no elevated privileges are required (unlike chmod'ing the mount point itself).
+TMPDIR is pointed at this directory in "openproject.env".
+*/}}
+{{- define "openproject.tmpVolumeInitContainer" -}}
+{{- if eq (include "openproject.fixTmpVolumePermissions" .) "true" }}
+- name: prepare-tmpdir
+  {{- include "openproject.containerSecurityContext" . | indent 2 }}
+  image: {{ include "openproject.image" . }}
+  imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+  command:
+    - sh
+    - -c
+    - mkdir -p /tmp/ruby && chmod 1777 /tmp/ruby
+  volumeMounts:
+    {{- include "openproject.tmpVolumeMounts" . | indent 4 }}
+{{- end }}
+{{- end -}}
+
 {{- define "openproject.tmpVolumeMounts" -}}
 {{- if eq (include "openproject.useTmpVolumes" .) "true" }}
 - mountPath: /tmp
@@ -200,6 +232,10 @@ securityContext:
 {{- end }}
 
 {{- define "openproject.env" -}}
+{{- if eq (include "openproject.fixTmpVolumePermissions" .) "true" }}
+- name: TMPDIR
+  value: /tmp/ruby
+{{- end }}
 {{- if .Values.metrics.enabled }}
 - name: OPENPROJECT_METRICS_ENABLED
   value: "true"

--- a/charts/openproject/templates/_helpers.tpl
+++ b/charts/openproject/templates/_helpers.tpl
@@ -126,6 +126,13 @@ TMPDIR is pointed at this directory in "openproject.env".
     - sh
     - -c
     - mkdir -p /tmp/ruby && chmod 1777 /tmp/ruby
+  {{- if .Values.appInit.resources }}
+  resources:
+    {{- toYaml .Values.appInit.resources | nindent 4 }}
+  {{- else if ne .Values.appInit.resourcesPreset "none" }}
+  resources:
+    {{- include "common.resources.preset" (dict "type" .Values.appInit.resourcesPreset) | nindent 4 }}
+  {{- end }}
   volumeMounts:
     {{- include "openproject.tmpVolumeMounts" . | indent 4 }}
 {{- end }}

--- a/charts/openproject/templates/cron-deployment.yaml
+++ b/charts/openproject/templates/cron-deployment.yaml
@@ -64,6 +64,7 @@ spec:
         {{- end }}
         {{- include "openproject.extraVolumes" . | indent 8 }}
       initContainers:
+        {{- include "openproject.tmpVolumeInitContainer" . | indent 8 }}
         - name: wait-for-db
           {{- include "openproject.containerSecurityContext" . | indent 10 }}
           image: {{ include "openproject.image" . }}

--- a/charts/openproject/templates/seeder-job.yaml
+++ b/charts/openproject/templates/seeder-job.yaml
@@ -48,6 +48,7 @@ spec:
         {{- end }}
         {{- include "openproject.extraVolumes" . | indent 8 }}
       initContainers:
+        {{- include "openproject.tmpVolumeInitContainer" . | indent 8 }}
         - name: check-db-ready
           image: "{{ .Values.dbInit.image.registry }}/{{ .Values.dbInit.image.repository }}:{{ .Values.dbInit.image.tag }}"
           imagePullPolicy: {{ .Values.dbInit.image.imagePullPolicy }}

--- a/charts/openproject/templates/web-deployment.yaml
+++ b/charts/openproject/templates/web-deployment.yaml
@@ -77,6 +77,7 @@ spec:
         {{- end }}
         {{- include "openproject.extraVolumes" . | indent 8 }}
       initContainers:
+        {{- include "openproject.tmpVolumeInitContainer" . | indent 8 }}
         - name: wait-for-db
           {{- include "openproject.containerSecurityContext" . | indent 10 }}
           image: {{ include "openproject.image" . }}

--- a/charts/openproject/templates/worker-deployment.yaml
+++ b/charts/openproject/templates/worker-deployment.yaml
@@ -72,6 +72,7 @@ spec:
         {{- end }}
         {{- include "openproject.extraVolumes" . | indent 8 }}
       initContainers:
+        {{- include "openproject.tmpVolumeInitContainer" . | indent 8 }}
         - name: wait-for-db
           {{- include "openproject.containerSecurityContext" . | indent 10 }}
           image: {{ include "openproject.image" . }}

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -685,6 +685,15 @@ openproject:
   #
   tmpVolumesLabels: {}
 
+  ## When using tmp volumes, some CSI drivers mount them world-writable without
+  ## the sticky bit. Ruby's Dir.tmpdir then rejects them, crashing every Ruby pod
+  ## at boot (MiniMagick / ActiveStorage). When enabled, an init container creates
+  ## a sticky-bit subdirectory (/tmp/ruby) as the non-root app user and TMPDIR is
+  ## pointed at it. Only takes effect when tmp volumes are in use. Opt out if it
+  ## causes issues on your platform.
+  #
+  tmpVolumesPermissionFix: true
+
 ## Whether to allocate persistent volume disk for the data directory.
 ## In case of node failure, the node data directory will still persist.
 ##

--- a/spec/charts/openproject/tmp_volume_permissions_spec.rb
+++ b/spec/charts/openproject/tmp_volume_permissions_spec.rb
@@ -30,6 +30,25 @@ describe 'tmp volume permission fix' do
       end
     end
 
+    it 'sizes the init container from appInit resources, matching wait-for-db', :aggregate_failures do
+      deployments.each_key do |item|
+        init = template.find_container(item, 'prepare-tmpdir', true)
+        expect(init['resources']).to eq('limits' => { 'memory' => '1024Mi' },
+                                        'requests' => { 'memory' => '512Mi' })
+      end
+    end
+
+    it 'falls back to the appInit resources preset when no explicit resources are set' do
+      preset_template = HelmTemplate.new(HelmTemplate.with_defaults(<<~YAML))
+        appInit:
+          resources: null
+          resourcesPreset: micro
+      YAML
+
+      init = preset_template.find_container('Deployment/optest-openproject-web', 'prepare-tmpdir', true)
+      expect(init['resources']['limits']).to include('cpu', 'memory')
+    end
+
     it 'orders prepare-tmpdir before the db-wait init container', :aggregate_failures do
       deployments.each do |item, (_main, db_init)|
         names = template.template_spec(item)['initContainers'].map { |c| c['name'] }

--- a/spec/charts/openproject/tmp_volume_permissions_spec.rb
+++ b/spec/charts/openproject/tmp_volume_permissions_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe 'tmp volume permission fix' do
+  # resource => [main container, db-wait init container]
+  let(:deployments) {
+    {
+      'Deployment/optest-openproject-web' => %w[openproject wait-for-db],
+      'Deployment/optest-openproject-worker-default' => %w[openproject wait-for-db],
+      'Deployment/optest-openproject-cron' => %w[cron wait-for-db],
+      /optest-openproject-seeder/ => %w[seeder check-db-ready]
+    }
+  }
+
+  context 'with tmp volumes enabled (default)' do
+    let(:template) { HelmTemplate.new(HelmTemplate.with_defaults({})) }
+
+    it 'adds a non-root prepare-tmpdir init container to every ruby pod', :aggregate_failures do
+      deployments.each_key do |item|
+        init = template.find_container(item, 'prepare-tmpdir', true)
+        expect(init).not_to be_nil, "expected prepare-tmpdir init container in #{item}"
+
+        security_context = init['securityContext']
+        expect(security_context['runAsNonRoot']).to be(true)
+        expect(security_context['runAsUser']).to eq(1000)
+        expect(security_context['readOnlyRootFilesystem']).to be(true)
+
+        expect(init['command'].last).to include('chmod 1777 /tmp/ruby')
+        expect(init['volumeMounts'].map { |mount| mount['name'] }).to include('tmp')
+      end
+    end
+
+    it 'orders prepare-tmpdir before the db-wait init container', :aggregate_failures do
+      deployments.each do |item, (_main, db_init)|
+        names = template.template_spec(item)['initContainers'].map { |c| c['name'] }
+        expect(names.index('prepare-tmpdir')).to be < names.index(db_init)
+      end
+    end
+
+    it 'points TMPDIR at the sticky-bit directory on the main and db-wait containers', :aggregate_failures do
+      deployments.each do |item, (main, db_init)|
+        expect(template.env_named(item, main, 'TMPDIR')&.dig('value')).to eq('/tmp/ruby')
+        expect(template.env_named(item, db_init, 'TMPDIR', true)&.dig('value')).to eq('/tmp/ruby')
+      end
+    end
+  end
+
+  context 'when opting out via tmpVolumesPermissionFix=false' do
+    let(:template) do
+      HelmTemplate.new(HelmTemplate.with_defaults(<<~YAML))
+        openproject:
+          tmpVolumesPermissionFix: false
+      YAML
+    end
+
+    it 'renders neither the init container nor TMPDIR', :aggregate_failures do
+      deployments.each do |item, (main, _db_init)|
+        expect(template.find_container(item, 'prepare-tmpdir', true)).to be_nil
+        expect(template.env_named(item, main, 'TMPDIR')).to be_nil
+      end
+    end
+  end
+
+  context 'when tmp volumes are disabled' do
+    let(:template) do
+      HelmTemplate.new(HelmTemplate.with_defaults(<<~YAML))
+        openproject:
+          useTmpVolumes: false
+      YAML
+    end
+
+    it 'renders neither the init container nor TMPDIR', :aggregate_failures do
+      deployments.each do |item, (main, _db_init)|
+        expect(template.find_container(item, 'prepare-tmpdir', true)).to be_nil
+        expect(template.env_named(item, main, 'TMPDIR')).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Using another variable openproject.tmpVolumesPermissionFix that is defaulting to true when we use tmp volumes, an init container now creates an owned subdirectory inside the world-writable mount and sets the sticky bit on that rather than trying to change the entire mount.

We then set TMPDIR env to force ruby to use that.
https://github.com/ruby/ruby/blob/master/lib/tmpdir.rb#L25-L45

https://community.openproject.org/projects/openproject/work_packages/75364/activity
