### PR TITLE
Maintenance: tmp volume defaults and docs

### DIFF
--- a/.changeset/olive-plums-attend.md
+++ b/.changeset/olive-plums-attend.md
@@ -1,5 +1,5 @@
 ---
-"@openproject/helm-charts": patch
+"@openproject/helm-charts": minor
 ---
 
 Make `openproject.useTmpVolumes` fall back to `containerSecurityContext.readOnlyRootFilesystem` rather than `not develop`.

--- a/.changeset/olive-plums-attend.md
+++ b/.changeset/olive-plums-attend.md
@@ -1,0 +1,5 @@
+---
+"@openproject/helm-charts": patch
+---
+
+Make `openproject.useTmpVolumes` fall back to `containerSecurityContext.readOnlyRootFilesystem` rather than `not develop`.

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -55,7 +55,5 @@ jobs:
             --helm-extra-set-args "\
               --set environment.OPENPROJECT_HTTPS=false \
               --set persistence.accessModes=[ReadWriteOnce] \
-              --set openproject.useTmpVolumes=false \
-              --set containerSecurityContext.readOnlyRootFilesystem=false \
             " \
             --helm-extra-args "--timeout 600s"

--- a/charts/openproject/DEVELOPMENT.md
+++ b/charts/openproject/DEVELOPMENT.md
@@ -97,3 +97,8 @@ Default login/password is admin/admin.
 
 You can create your own file adding to and overriding values and pass that with
 an additional `-f` option in the command above. For instance `bin/install-dev -f my-values.yaml`.
+
+### TLS
+
+If you want to use TLS you can use [`bin/install-local-with-tls`](./bin/install-local-with-tls).
+This will generate a self-signed certificate the root CA of which you will have to import into your browser.

--- a/charts/openproject/README.md
+++ b/charts/openproject/README.md
@@ -121,12 +121,12 @@ openproject.admin_user.mail="admin@example.com"
 
 ### TMP volume mounts
 
-OpenProject needs some tmp volumes to be mounted in `/app/tmp`  and `/tmp`, if `global.containerSecurityContext.readOnlyRootFilesystem` is set to true.
+OpenProject needs some tmp volumes to be mounted in `/app/tmp`  and `/tmp`, if `containerSecurityContext.readOnlyRootFilesystem` is set to true.
 This is due to the application server storing a non-configurable PID file and some temporary caches or files being put there.
 
-This setting is true by default (to be precise, it follows its configured value or falls back to `develop != true`)
+This setting is true by default (to be precise, it follows its configured value or falls back to `containerSecurityContext.readOnlyRootFilesystem`).
 
-To explicitly disable this, use `openproject.useTmpVolumes=false`. This will fail if `readOnlyRootFilesystem=true`.
+To explicitly disable this, use `openproject.useTmpVolumes=false`. This will fail if `readOnlyRootFilesystem` is `true`.
 
 These volumes do not contain any critical information and can be excluded from backups using the labels/annotations values.
 

--- a/charts/openproject/bin/install-dev
+++ b/charts/openproject/bin/install-dev
@@ -22,7 +22,7 @@ helm upgrade \
   --create-namespace --namespace openproject \
   --install openproject \
   --set develop=true \
-  --set ingress.host=helm.openproject-dev.com \
+  --set ingress.host=openproject.localhost \
   --set openproject.realtime_collaboration.hocuspocus.protocol=ws \
   --set persistence.accessModes=['ReadWriteOnce'] \
   "$@" .

--- a/charts/openproject/examples/local-with-tls-values.yaml
+++ b/charts/openproject/examples/local-with-tls-values.yaml
@@ -14,14 +14,6 @@ persistence:
   accessModes:
     - "ReadWriteOnce" # effectively the same as ReadWriteMany on a single node k3s dev cluster
 
-# We disable tmp volumes and the read-only file system because on local-path volumes
-# the permissions are too open for Ruby and it will crash saying it can't
-# determine a temp directory.
-openproject:
-  useTmpVolumes: false
-containerSecurityContext:
-  readOnlyRootFilesystem: false
-
 environment:
   OPENPROJECT_SEED__ADMIN__USER__PASSWORD__RESET: false # so we can just keep logging in with admin:admin
 

--- a/charts/openproject/templates/_helpers.tpl
+++ b/charts/openproject/templates/_helpers.tpl
@@ -95,7 +95,7 @@ securityContext:
 {{- if ne .Values.openproject.useTmpVolumes nil -}}
   {{- .Values.openproject.useTmpVolumes -}}
 {{- else -}}
-  {{- (not .Values.develop) -}}
+  {{- .Values.containerSecurityContext.readOnlyRootFilesystem -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/openproject/values.yaml
+++ b/charts/openproject/values.yaml
@@ -665,7 +665,7 @@ openproject:
   annotations: {}
 
   ## Whether or not to use ephemeral volumes for /app/tmp and /tmp.
-  ## Falls back to a sensible default if undefined.
+  ## Falls back to `containerSecurityContext.readOnlyRootFilesystem` if undefined.
   #
   useTmpVolumes:
 


### PR DESCRIPTION
After the sticky bit issue with tmp volumes has been fixed, we no longer need to disable them for development with or without TLS.