### PR TITLE
support releasing multiple independently versioned charts

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -34,6 +34,9 @@ jobs:
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
+          if grep -qx 'charts/openproject' <<< "$changed"; then
+            echo "openproject-changed=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Run chart-testing (lint) WITHOUT version check
         if: github.event.pull_request.title != 'Release Tracking'
@@ -45,12 +48,13 @@ jobs:
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.5.0
-        if: steps.list-changed.outputs.changed == 'true'
+        if: steps.list-changed.outputs.openproject-changed == 'true'
 
-      - name: Run chart-testing (install)
+      - name: Run chart-testing (install) for OpenProject
+        if: steps.list-changed.outputs.openproject-changed == 'true'
         run: |
           ct install \
-            --target-branch ${{ github.event.repository.default_branch }} \
+            --charts charts/openproject \
             --chart-repos bitnami=https://charts.bitnami.com/bitnami \
             --helm-extra-set-args "\
               --set environment.OPENPROJECT_HTTPS=false \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up Helm
         uses: azure/setup-helm@v3
@@ -21,8 +23,55 @@ jobs:
           # runs 'bundle install' and caches installed gems automatically
           bundler-cache: true
 
+      - name: Determine charts to test
+        id: changed
+        run: |
+          changed_files=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")
+
+          echo "Changed files:"
+          echo "$changed_files"
+
+          all_charts=$(ls -d charts/*/ | sed 's#charts/##; s#/##')
+
+          # Shared spec framework/tooling files affect every chart's tests, so test everything.
+          if echo "$changed_files" | grep -qE '^(Gemfile|Gemfile\.lock|\.rspec)$|^spec/[^/]+$'; then
+            charts="$all_charts"
+          else
+            charts=$(echo "$changed_files" \
+              | grep -oE '^(charts/[^/]+|spec/charts/[^/]+)' \
+              | sed -E 's#^charts/##; s#^spec/charts/##' \
+              | sort -u)
+          fi
+
+          echo "Charts to test:"
+          echo "$charts"
+
+          echo "charts<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$charts" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
       - name: Prepare environment
-        run: cd charts/openproject && helm dependency update
+        if: steps.changed.outputs.charts != ''
+        run: |
+          while IFS= read -r chart; do
+            [ -z "$chart" ] && continue
+            (cd "charts/$chart" && helm dependency update)
+          done <<< "${{ steps.changed.outputs.charts }}"
 
       - name: Run tests
-        run: bundle exec rspec
+        if: steps.changed.outputs.charts != ''
+        run: |
+          spec_dirs=""
+          while IFS= read -r chart; do
+            [ -z "$chart" ] && continue
+            if [ -d "spec/charts/$chart" ]; then
+              spec_dirs="$spec_dirs spec/charts/$chart"
+            fi
+          done <<< "${{ steps.changed.outputs.charts }}"
+
+          if [ -z "$spec_dirs" ]; then
+            echo "No chart changes with matching specs; nothing to test."
+            exit 0
+          fi
+
+          bundle exec rspec $spec_dirs

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 charts/openproject/charts
-charts/openproject/RELEASE-NOTES.md
+charts/*/RELEASE-NOTES.md
 Chart.lock
 node_modules/
 .cr-gpg/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This is the OpenProject Helm Charts repository, containing Kubernetes deployment
 ### Release Management
 - `npm run changeset:version` - Update version numbers and generate changelog using changesets
 - `bin/update_from_core_release <version>` - Update chart to track a new OpenProject core release
-- `script/version` - Sync Chart.yaml version with package.json version
+- `script/version` - Sync each chart's Chart.yaml version with its own `charts/<chart>/package.json` version
 
 ### Helm Operations
 - `helm dependency update` - Update chart dependencies (required before testing)
@@ -67,8 +67,9 @@ The `bin/update_from_core_release` script automates updating to new OpenProject 
 
 Uses Changesets for automated release management:
 - `.changeset/` directory contains pending changes
+- Each chart under `charts/*` is its own npm workspace package (see `charts/<chart>/package.json`), versioned independently by changesets. A changeset's frontmatter names the package(s) it bumps (e.g. `"openproject": patch`), so a change scoped to one chart only versions and releases that chart.
 - `npm run changeset:version` processes changesets and updates versions
-- Chart releases are automated via GitHub Actions with chart-releaser
+- Chart releases are automated via GitHub Actions with chart-releaser, which creates one GitHub Release per chart (tagged `<chart-name>-<version>`) and only for charts whose version actually changed
 - Charts are signed using GPG key (fingerprint in `Chart.yaml` annotations)
 
 ## Development Workflow
@@ -83,6 +84,6 @@ Uses Changesets for automated release management:
 ## Key Files
 - `charts/openproject/Chart.yaml:8` - App version (OpenProject core version)
 - `charts/openproject/Chart.yaml:9` - Chart version  
-- `package.json:5` - NPM package version (synced with chart version)
+- `charts/openproject/package.json` - NPM package version for this chart (synced into Chart.yaml by `script/version`)
 - `spec/helm_template.rb` - Test framework for Helm template rendering
 - `bin/update_from_core_release` - Core version update automation

--- a/bin/update_from_core_release
+++ b/bin/update_from_core_release
@@ -59,7 +59,7 @@ changeset_name = "#{next_version.to_s.gsub('.', '-')}_#{bump_type}.md"
 File.open(File.expand_path("../.changeset/#{changeset_name}", __dir__), 'w') do |f|
   f.write <<~CHANGE
     ---
-    "@openproject/helm-charts": #{bump_type}
+    "openproject": #{bump_type}
     ---
 
     Upgrade OpenProject core version to #{next_version} (#{bump_type} update)

--- a/charts/openproject/CHANGELOG.md
+++ b/charts/openproject/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @openproject/helm-charts
+# openproject
 
 ## 13.8.1
 

--- a/charts/openproject/package.json
+++ b/charts/openproject/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "openproject",
+    "private": true,
+    "version": "13.8.1"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,15 @@
     "packages": {
         "": {
             "name": "@openproject/helm-charts",
-            "version": "10.5.0",
+            "workspaces": [
+                "charts/*"
+            ],
             "devDependencies": {
                 "@changesets/cli": "^2.27.1"
             }
+        },
+        "charts/openproject": {
+            "version": "13.8.1"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.23.5",
@@ -1908,6 +1913,10 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/openproject": {
+            "resolved": "charts/openproject",
+            "link": true
         },
         "node_modules/os-tmpdir": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
     "name": "@openproject/helm-charts",
     "private": true,
     "author": "OpenProject GmbH",
-    "version": "13.8.1",
     "license": "",
+    "workspaces": [
+        "charts/*"
+    ],
     "scripts": {
         "changeset:version": "./node_modules/.bin/changeset version && script/version"
     },

--- a/script/extract-changeset
+++ b/script/extract-changeset
@@ -2,16 +2,20 @@
 require 'json'
 require 'yaml'
 
-changelog_file = File.expand_path('../CHANGELOG.md', __dir__)
-changelog = File.read changelog_file
+root = File.expand_path('..', __dir__)
 
-chart_file = File.expand_path('../charts/openproject/RELEASE-NOTES.md', __dir__)
-release_notes = changelog.split(/^## \d+\.\d+\.\d+$/)[1]
+Dir.glob(File.join(root, 'charts/*/CHANGELOG.md')).each do |changelog_file|
+  chart_dir = File.dirname(changelog_file)
+  changelog = File.read changelog_file
 
-puts "Writing to #{chart_file}:"
-puts release_notes
+  release_notes = changelog.split(/^## \d+\.\d+\.\d+$/)[1]
+  next unless release_notes
 
-File.open(chart_file, 'w') do |f|
+  release_notes_file = File.join(chart_dir, 'RELEASE-NOTES.md')
+  puts "Writing to #{release_notes_file}:"
+  puts release_notes
+
+  File.open(release_notes_file, 'w') do |f|
     f.write release_notes
+  end
 end
-

--- a/script/version
+++ b/script/version
@@ -2,14 +2,18 @@
 require 'json'
 require 'yaml'
 
-package_file = File.expand_path('../package.json', __dir__)
-package_content = JSON.parse File.read(package_file)
-new_version = package_content['version']
+root = File.expand_path('..', __dir__)
 
-chart_file = File.expand_path('../charts/openproject/Chart.yaml', __dir__)
-contents = YAML.load_file chart_file
-contents['version'] = new_version
-File.open(chart_file, 'w') do |f|
+Dir.glob(File.join(root, 'charts/*/package.json')).each do |package_file|
+  chart_dir = File.dirname(package_file)
+  chart_file = File.join(chart_dir, 'Chart.yaml')
+  next unless File.exist?(chart_file)
+
+  new_version = JSON.parse(File.read(package_file))['version']
+
+  contents = YAML.load_file chart_file
+  contents['version'] = new_version
+  File.open(chart_file, 'w') do |f|
     f.write contents.to_yaml
+  end
 end
-


### PR DESCRIPTION
In #339 we want to add a new chart to the helm repo.
However, the current configuration is hard-coded to release only a single chart (openproject).

This PR adjusts the configuration and scripts to support multiple helm charts in the repository which can all be released independently using the same changeset-based mechanism.

The actual chart releaser action already supports multiple charts. It was just our changeset mechanism for bumping the chart versions that didn't.