### PR TITLE
increased default token limit to 10M/d, fixed casing of property names

### DIFF
--- a/charts/llm-stack/templates/apisix-config-seeder-configmap.yaml
+++ b/charts/llm-stack/templates/apisix-config-seeder-configmap.yaml
@@ -60,9 +60,9 @@ data:
                     "key": consumer["key"]
                 },
                 "ai-rate-limiting": {
-                    "limit": {{ .Values.apisixInitialConfig.consumer_usage_limits.num_tokens}},
-                    "time_window": {{ .Values.apisixInitialConfig.consumer_usage_limits.time_window_seconds }},
-                    "limit_strategy": {{ .Values.apisixInitialConfig.consumer_usage_limits.limit_strategy | quote }}
+                    "limit": {{ .Values.apisixInitialConfig.consumerUsageLimits.numTokens}},
+                    "time_window": {{ .Values.apisixInitialConfig.consumerUsageLimits.timeWindowSeconds }},
+                    "limit_strategy": {{ .Values.apisixInitialConfig.consumerUsageLimits.limitStrategy | quote }}
                 },
             }
         } for consumer in consumer_data

--- a/charts/llm-stack/values.yaml
+++ b/charts/llm-stack/values.yaml
@@ -11,10 +11,10 @@ apisixInitialConfig:
         provider: scaleway
       - name: gemma-4-26b-a4b-it
         provider: scaleway
-  consumer_usage_limits:
-    num_tokens: 1000000
-    time_window_seconds: 86400  # 24h
-    limit_strategy: total_tokens
+  consumerUsageLimits:
+    numTokens: 10000000
+    timeWindowSeconds: 86400  # 24h
+    limitStrategy: total_tokens
   secrets:
     name: "llm-stack-apisix-initial-config-secret"
     providerApiKeyKey: "provider_api_key"


### PR DESCRIPTION

# What are you trying to accomplish?
* Increase daily token limit to 10M to allow for current MCP-based testing.
* Fixed casing of property names in the allowed usage section
